### PR TITLE
[feat] 결제 실패 알림 시스템 및 Auto-Cancel 구현

### DIFF
--- a/src/main/java/com/ureca/snac/infra/dto/response/TossPaymentInquiryResponse.java
+++ b/src/main/java/com/ureca/snac/infra/dto/response/TossPaymentInquiryResponse.java
@@ -1,0 +1,27 @@
+package com.ureca.snac.infra.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.OffsetDateTime;
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossPaymentInquiryResponse(
+        String paymentKey,
+        String orderId,
+        String status,
+        String method,
+        Long totalAmount,
+        OffsetDateTime approvedAt
+) {
+    private static final Set<String> CANCELED_OR_FAILED_STATUSES =
+            Set.of("CANCELED", "ABORTED", "EXPIRED");
+
+    public boolean isDone() {
+        return "DONE".equals(status);
+    }
+
+    public boolean isCanceledOrFailed() {
+        return CANCELED_OR_FAILED_STATUSES.contains(status);
+    }
+}

--- a/src/main/java/com/ureca/snac/money/service/MoneyServiceImpl.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyServiceImpl.java
@@ -10,9 +10,11 @@ import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
 import com.ureca.snac.money.dto.MoneyRechargeRequest;
 import com.ureca.snac.money.dto.MoneyRechargeSuccessResponse;
 import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.event.alert.AutoCancelFailureEvent;
 import com.ureca.snac.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +23,8 @@ import static com.ureca.snac.common.BaseCode.PAYMENT_INTERNAL_ERROR;
 /**
  * 머니 충전 서비스 Fail-Fast
  * Toss 승인 실패 -> 예외 전파 (출금 안됨, 취소 필요 없음)
- * Toss 승인 성공 + DB 실패 -> 로깅 후 예외 전파
+ * Toss 승인 성공 + DB 실패 -> Auto-Cancel 시도 (출금 됨, 반드시 취소 필요)
+ * Auto-Cancel 마저 실패 -> Slack 알림 (수동 복구 필요)
  */
 @Slf4j
 @Service
@@ -33,6 +36,8 @@ public class MoneyServiceImpl implements MoneyService {
     private final PaymentGatewayAdapter paymentGatewayAdapter;
     // 머니 입금 DB 처리 담당 서비스
     private final MoneyDepositor moneyDepositor;
+    // 이벤트 발행
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -88,12 +93,40 @@ public class MoneyServiceImpl implements MoneyService {
             // DB 저장 시도
             moneyDepositor.deposit(payment, member, tossConfirmResponse);
         } catch (Exception e) {
-            // Toss 성공 -> 우리 DB 실패
-            log.error("[결제 누락 위험] Toss 승인 완료 but DB 실패. orderId: {}", orderId, e);
+            // Toss 성공 -> 우리 DB 실패 Auto-Cancel
+            log.error("[결제 누락 위험] Toss 승인 완료 but DB 실패. Auto-Cancel 시도. orderId: {}", orderId);
+
+            autoCancelAfterConfirmSuccess(payment, tossConfirmResponse.paymentKey(), e);
             throw new InternalServerException(PAYMENT_INTERNAL_ERROR);
         }
         log.info("[머니 충전 처리 완료] 모든 프로세스 종료");
 
         return MoneyRechargeSuccessResponse.of(orderId, paymentKey, amount);
+    }
+
+    // Toss 승인 성공 후 Auto-Cancel 실패 시 이벤트 발행
+    private void autoCancelAfterConfirmSuccess(Payment payment, String paymentKey, Exception cause) {
+
+        try {
+            paymentGatewayAdapter.cancelPayment(paymentKey, "Auto-cancel : DB 처리 실패");
+
+            paymentService.markAsCanceled(payment.getId(), "internal error by Auto-cancel");
+
+            log.info("[Auto-Cancel 성공] paymentKey: {}", paymentKey);
+        } catch (Exception cancelException) {
+            // Auto-Cancel 실패 -> 이벤트 발행
+            log.error("[Auto-Cancel 실패] 수동 복구 필요. paymentKey: {}, orderId: {}, amount: {}, 원인: {}, 취소실패원인: {}",
+                    paymentKey, payment.getOrderId(), payment.getAmount(), cause.getMessage(), cancelException.getMessage());
+
+            eventPublisher.publishEvent(new AutoCancelFailureEvent(
+                    payment.getId(),
+                    payment.getMember().getId(),
+                    payment.getAmount(),
+                    payment.getOrderId(),
+                    paymentKey,
+                    cause.getMessage(),
+                    cancelException.getMessage()
+            ));
+        }
     }
 }

--- a/src/main/java/com/ureca/snac/payment/event/alert/AutoCancelFailureEvent.java
+++ b/src/main/java/com/ureca/snac/payment/event/alert/AutoCancelFailureEvent.java
@@ -1,0 +1,26 @@
+package com.ureca.snac.payment.event.alert;
+
+/**
+ * Auto-Cancel 실패 이벤트
+ * <p>
+ * Toss 결제 승인 응답 + 우리 DB 처리 실패 + 자동 취소 API 요청 실패 시 발행 되는 이벤트
+ * 반드시 수동 복구 필요
+ *
+ * @param paymentId          결제 ID
+ * @param memberId           회원 ID
+ * @param amount             결제 금액
+ * @param orderId            주문 ID
+ * @param paymentKey         Toss 결제 키
+ * @param dbErrorMessage     DB 처리 실패 오류 메시지
+ * @param cancelErrorMessage 자동 취소 실패 오류 메시지
+ */
+public record AutoCancelFailureEvent(
+        Long paymentId,
+        Long memberId,
+        Long amount,
+        String orderId,
+        String paymentKey,
+        String dbErrorMessage,
+        String cancelErrorMessage
+) implements CriticalPaymentFailureEvent {
+}

--- a/src/main/java/com/ureca/snac/payment/event/alert/CompensationFailureEvent.java
+++ b/src/main/java/com/ureca/snac/payment/event/alert/CompensationFailureEvent.java
@@ -1,0 +1,32 @@
+package com.ureca.snac.payment.event.alert;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 결제 취소 보상 처리 실패 이벤트
+ * <p>
+ * Toss에서는 취소되었으나 시스템 잔액이 갱신되지 않은 상태
+ * 반드시 수동 복구 필요
+ *
+ * @param paymentId                결제 ID
+ * @param memberId                 회원 ID
+ * @param amount                   결제 금액
+ * @param orderId                  주문 ID
+ * @param paymentKey               Toss 결제 키
+ * @param cancelReason             취소 사유
+ * @param canceledAt               Toss 취소 완료 시각
+ * @param originalErrorMessage     원본 DB 처리 실패 오류 메시지
+ * @param compensationErrorMessage 보상 처리 실패 오류 메시지
+ */
+public record CompensationFailureEvent(
+        Long paymentId,
+        Long memberId,
+        Long amount,
+        String orderId,
+        String paymentKey,
+        String cancelReason,
+        OffsetDateTime canceledAt,
+        String originalErrorMessage,
+        String compensationErrorMessage
+) implements CriticalPaymentFailureEvent {
+}

--- a/src/main/java/com/ureca/snac/payment/event/alert/CriticalPaymentFailureEvent.java
+++ b/src/main/java/com/ureca/snac/payment/event/alert/CriticalPaymentFailureEvent.java
@@ -1,0 +1,20 @@
+package com.ureca.snac.payment.event.alert;
+
+/**
+ * 결제 관련 실패 이벤트 인터페이스
+ * <p>
+ * 운영자 알림이 반드시 필요한 치명적인 실패 상황
+ * AutoCancelFailureEvent: Toss 승인 성공 + DB 실패 + 자동 취소 실패
+ * CompensationFailureEvent: Toss 결제 취소 성공 + 우리 DB 보상 처리 실패
+ */
+public sealed interface CriticalPaymentFailureEvent
+        permits AutoCancelFailureEvent, CompensationFailureEvent {
+
+    Long paymentId();
+
+    Long memberId();
+
+    Long amount();
+
+    String orderId();
+}

--- a/src/main/java/com/ureca/snac/payment/listener/CriticalPaymentFailureAlertListener.java
+++ b/src/main/java/com/ureca/snac/payment/listener/CriticalPaymentFailureAlertListener.java
@@ -1,0 +1,41 @@
+package com.ureca.snac.payment.listener;
+
+import com.ureca.snac.config.AsyncConfig;
+import com.ureca.snac.payment.event.alert.AutoCancelFailureEvent;
+import com.ureca.snac.payment.event.alert.CompensationFailureEvent;
+import com.ureca.snac.payment.event.alert.CriticalPaymentFailureEvent;
+import com.ureca.snac.payment.service.PaymentAlertService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 결제 관련 치명적 실패 이벤트 통합 리스너
+ * <p>
+ * 비동기로 Slack 알림 발송 (메인 트랜잭션에 영향 없음)
+ * AFTER_COMPLETION: commit/rollback 무관하게 실행
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CriticalPaymentFailureAlertListener {
+
+    private final PaymentAlertService paymentAlertService;
+
+    @Async(AsyncConfig.NOTIFICATION_EXECUTOR_NAME)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
+    public void handleCriticalFailure(CriticalPaymentFailureEvent event) {
+        try {
+            if (event instanceof AutoCancelFailureEvent e) {
+                paymentAlertService.alertAutoCancelFailure(e);
+            } else if (event instanceof CompensationFailureEvent e) {
+                paymentAlertService.alertCompensationFailure(e);
+            }
+        } catch (Exception e) {
+            log.error("[CRITICAL ALERT FAILURE] 알림 발송 실패. paymentId: {}", event.paymentId(), e);
+        }
+    }
+}

--- a/src/main/java/com/ureca/snac/payment/service/PaymentAlertService.java
+++ b/src/main/java/com/ureca/snac/payment/service/PaymentAlertService.java
@@ -1,0 +1,128 @@
+package com.ureca.snac.payment.service;
+
+import com.ureca.snac.common.notification.SlackNotifier;
+import com.ureca.snac.common.notification.dto.SlackAttachment;
+import com.ureca.snac.common.notification.dto.SlackField;
+import com.ureca.snac.common.notification.dto.SlackMessage;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.event.alert.AutoCancelFailureEvent;
+import com.ureca.snac.payment.event.alert.CompensationFailureEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 결제 관련 알림 서비스
+ * <p>
+ * 결제 처리 중 발생하는 치명적인 상황에 대한 Slack 알림 담당
+ * MoneyServiceImpl에서 알림 책임 분리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentAlertService {
+
+    private final SlackNotifier slackNotifier;
+
+    // Auto-Cancel 실패 시 운영자 알림
+    public void alertAutoCancelFailure(AutoCancelFailureEvent event) {
+        List<SlackField> fields = List.of(
+                SlackField.of("Payment ID", String.valueOf(event.paymentId())),
+                SlackField.of("Payment Key", event.paymentKey()),
+                SlackField.of("Order ID", event.orderId()),
+                SlackField.of("Amount", event.amount() + "원"),
+                SlackField.longField("DB Error", event.dbErrorMessage()),
+                SlackField.longField("Cancel Error", event.cancelErrorMessage()),
+                SlackField.longField("조치",
+                        """
+                                1. Toss 관리자 콘솔에서 결제 상태 확인
+                                2. 수동 취소 또는 DB 동기화 결정
+                                3. Payment ID로 DB 상태 확인
+                                """)
+        );
+        SlackAttachment attachment = SlackAttachment.danger(fields);
+        SlackMessage message = SlackMessage.of("CRITICAL: 결제 자동취소 실패", attachment);
+
+        log.error("[CRITICAL] Auto-Cancel 실패! paymentKey: {}, orderId: {}",
+                event.paymentKey(), event.orderId());
+        slackNotifier.sendAsync(message);
+    }
+
+    /**
+     * Toss 취소 성공 후 DB 보상 처리마저 실패한 Critical 상황 잔액 불일치 발생 가능
+     * 결제 취소 보상 처리 실패 시 운영자 알림
+     */
+    public void alertCompensationFailure(CompensationFailureEvent event) {
+        List<SlackField> fields = List.of(
+                SlackField.of("Payment ID", String.valueOf(event.paymentId())),
+                SlackField.of("Member ID", String.valueOf(event.memberId())),
+                SlackField.of("Payment Key", event.paymentKey()),
+                SlackField.of("Order ID", event.orderId()),
+                SlackField.of("Amount", event.amount() + "원"),
+                SlackField.of("Cancel Reason", event.cancelReason()),
+                SlackField.of("Canceled At", event.canceledAt().toString()),
+                SlackField.longField("Original Error", event.originalErrorMessage()),
+                SlackField.longField("Compensation Error", event.compensationErrorMessage()),
+                SlackField.longField("조치",
+                        """
+                                1. Toss 관리자 콘솔에서 취소 상태 확인
+                                2. DB에서 Payment 상태 확인 (CANCELED 여부)
+                                3. Wallet 잔액 수동 조정 필요
+                                4. AssetHistory 기록 수동 추가
+                                """)
+        );
+        SlackAttachment attachment = SlackAttachment.danger(fields);
+        SlackMessage message = SlackMessage.of("CRITICAL: 결제 취소 보상 처리 실패", attachment);
+
+        log.error("[CRITICAL] 보상 처리 실패! paymentId: {}, memberId: {}, amount: {}",
+                event.paymentId(), event.memberId(), event.amount());
+        slackNotifier.sendAsync(message);
+    }
+
+    // 대사 스케줄러 자동 취소 성공 시 운영자 알림
+    public void alertReconciliationAutoCanceled(Payment payment, String paymentKey) {
+        List<SlackField> fields = List.of(
+                SlackField.of("Payment ID", String.valueOf(payment.getId())),
+                SlackField.of("Payment Key", paymentKey),
+                SlackField.of("Order ID", payment.getOrderId()),
+                SlackField.of("Amount", payment.getAmount() + "원"),
+                SlackField.longField("조치", "자동 취소 완료. 추가 조치 불필요")
+        );
+        SlackAttachment attachment = SlackAttachment.warning(fields);
+        SlackMessage message = SlackMessage.of("대사: 미결 결제 자동 취소 완료", attachment);
+
+        log.warn("[대사] 자동 취소 완료. paymentId: {}, orderId: {}", payment.getId(), payment.getOrderId());
+        slackNotifier.sendAsync(message);
+    }
+
+    /**
+     * 대사 스케줄러 자동 취소 실패 시 운영자 알림
+     *
+     * @param payment      취소 실패한 결제
+     * @param paymentKey   토스 결제 키
+     * @param errorMessage 에러 메시지
+     */
+    public void alertReconciliationCancelFailed(Payment payment, String paymentKey, String errorMessage) {
+        List<SlackField> fields = List.of(
+                SlackField.of("Payment ID", String.valueOf(payment.getId())),
+                SlackField.of("Payment Key", paymentKey),
+                SlackField.of("Order ID", payment.getOrderId()),
+                SlackField.of("Amount", payment.getAmount() + "원"),
+                SlackField.longField("Error", errorMessage),
+                SlackField.longField("조치",
+                        """
+                                1. Toss 관리자 콘솔에서 결제 상태 확인
+                                2. 수동 취소 또는 DB 동기화 결정
+                                3. Payment ID로 DB 상태 확인
+                                """)
+        );
+        SlackAttachment attachment = SlackAttachment.danger(fields);
+        SlackMessage message = SlackMessage.of("CRITICAL: 대사 자동 취소 실패", attachment);
+
+        log.error("[CRITICAL] 대사 자동 취소 실패! paymentId: {}, orderId: {}, error: {}",
+                payment.getId(), payment.getOrderId(), errorMessage);
+        slackNotifier.sendAsync(message);
+    }
+}

--- a/src/main/java/com/ureca/snac/payment/service/PaymentInternalService.java
+++ b/src/main/java/com/ureca/snac/payment/service/PaymentInternalService.java
@@ -8,6 +8,7 @@ import com.ureca.snac.payment.dto.PaymentCancelResponse;
 import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.entity.PaymentStatus;
 import com.ureca.snac.payment.event.PaymentCancelCompensationEvent;
+import com.ureca.snac.payment.event.alert.CompensationFailureEvent;
 import com.ureca.snac.payment.exception.PaymentNotFoundException;
 import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.wallet.service.WalletService;
@@ -113,6 +114,19 @@ public class PaymentInternalService {
                     originalError.getMessage(),
                     compensationError.getMessage(),
                     compensationError);
+
+            // 운영자 알림 이벤트 발행
+            eventPublisher.publishEvent(new CompensationFailureEvent(
+                    payment.getId(),
+                    member.getId(),
+                    payment.getAmount(),
+                    payment.getOrderId(),
+                    payment.getPaymentKey(),
+                    cancelResponse.reason(),
+                    cancelResponse.canceledAt(),
+                    originalError.getMessage(),
+                    compensationError.getMessage()
+            ));
         }
     }
 

--- a/src/test/java/com/ureca/snac/infra/fixture/TossResponseFixture.java
+++ b/src/test/java/com/ureca/snac/infra/fixture/TossResponseFixture.java
@@ -1,0 +1,31 @@
+package com.ureca.snac.infra.fixture;
+
+import com.ureca.snac.infra.dto.response.TossCancelResponse;
+import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+// Toss API 응답 테스트 Fixture (infra 도메인 전용)
+public class TossResponseFixture {
+
+    public static TossConfirmResponse createConfirmResponse(String paymentKey) {
+        return new TossConfirmResponse(paymentKey, "카드", OffsetDateTime.now());
+    }
+
+    public static TossCancelResponse createCancelResponse(String paymentKey, Long amount, String reason) {
+        TossCancelResponse.Cancel cancel = new TossCancelResponse.Cancel(
+                amount, reason, OffsetDateTime.now()
+        );
+        return new TossCancelResponse(paymentKey, "snac_order_test", List.of(cancel));
+    }
+
+    public static TossPaymentInquiryResponse createInquiryResponse(
+            String paymentKey, String orderId, String status) {
+        OffsetDateTime approvedAt = "DONE".equals(status) ? OffsetDateTime.now() : null;
+        return new TossPaymentInquiryResponse(
+                paymentKey, orderId, status, "카드", 10000L, approvedAt
+        );
+    }
+}

--- a/src/test/java/com/ureca/snac/integration/PaymentAsyncEventIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/PaymentAsyncEventIntegrationTest.java
@@ -1,0 +1,272 @@
+package com.ureca.snac.integration;
+
+import com.ureca.snac.asset.entity.AssetHistory;
+import com.ureca.snac.asset.entity.TransactionCategory;
+import com.ureca.snac.common.event.AggregateType;
+import com.ureca.snac.common.event.EventType;
+import com.ureca.snac.config.AggregateExchangeMapper;
+import com.ureca.snac.config.RabbitMQQueue;
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.infra.fixture.TossResponseFixture;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
+import com.ureca.snac.money.dto.MoneyRechargeRequest;
+import com.ureca.snac.money.service.MoneyService;
+import com.ureca.snac.outbox.entity.Outbox;
+import com.ureca.snac.outbox.entity.OutboxStatus;
+import com.ureca.snac.payment.dto.PaymentCancelResponse;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.service.PaymentInternalService;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.support.fixture.EventFixture;
+import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
+import com.ureca.snac.wallet.entity.Wallet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.QueueInformation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 결제 비동기 이벤트 통합 테스트
+ * RabbitMQ Listener, 보상 트랜잭션, DLQ 라우팅
+ */
+@DisplayName("결제 비동기 이벤트 통합 테스트")
+class PaymentAsyncEventIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MoneyService moneyService;
+
+    @Autowired
+    private PaymentInternalService paymentInternalService;
+
+    @MockitoBean
+    private PaymentGatewayAdapter paymentGatewayAdapter;
+
+    private Member member;
+
+    private static final Long RECHARGE_AMOUNT = 10000L;
+    private static final Duration ASYNC_TIMEOUT = Duration.ofSeconds(15);
+
+    @BeforeEach
+    void setUpMember() {
+        member = createMemberWithWallet("async_");
+    }
+
+    @Nested
+    @DisplayName("보상 이벤트")
+    class CompensationEventTest {
+
+        @Test
+        @DisplayName("성공 : 보상 이벤트 → Wallet 출금 + AssetHistory + compensationCompleted")
+        void shouldProcessCompensationEvent() {
+            // given: 충전 완료 후 CANCELED 상태로 변경 (토스 취소 성공 시뮬레이션)
+            Payment canceledPayment = createCanceledPayment();
+
+            // when: 보상 이벤트 발행
+            publishCompensationEvent(canceledPayment);
+
+            // then: 비동기 처리 완료 대기
+            waitForCompensationCompleted(canceledPayment.getId());
+
+            // Wallet 출금 확인
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isZero();
+
+            // AssetHistory CANCEL 기록
+            List<AssetHistory> cancelHistories = assetHistoryRepository.findAll().stream()
+                    .filter(h -> h.getCategory() == TransactionCategory.RECHARGE_CANCEL)
+                    .toList();
+            assertThat(cancelHistories).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("멱등성 : 동일 이벤트 2회 발행 → Wallet 출금 1회만")
+        void shouldBeIdempotentForDuplicateEvents() {
+            // given
+            Payment canceledPayment = createCanceledPayment();
+
+            // when: 동일 이벤트 2회 발행
+            publishCompensationEvent(canceledPayment);
+            publishCompensationEvent(canceledPayment);
+
+            // then: 처리 완료 대기
+            waitForCompensationCompleted(canceledPayment.getId());
+            waitForQueueEmpty(RabbitMQQueue.PAYMENT_CANCEL_COMPENSATE_QUEUE);
+
+            // Wallet 잔액 0 (1회만 출금)
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isZero();
+        }
+
+        @Test
+        @DisplayName("실패 : 잘못된 JSON → DLQ 이동")
+        void shouldSendInvalidJsonToDLQ() {
+            // when: 잘못된 JSON 발행
+            publishRawMessage(EventFixture.invalidJson());
+
+            // then: DLQ에 메시지 도착
+            waitForDLQ(RabbitMQQueue.PAYMENT_CANCEL_COMPENSATE_DLQ, 1);
+            assertQueueEmpty(RabbitMQQueue.PAYMENT_CANCEL_COMPENSATE_QUEUE);
+        }
+
+        @Test
+        @DisplayName("실패 : Payment 없음 → 재시도 후 DLQ")
+        void shouldRetryThenDLQWhenPaymentNotFound() {
+            // when: 존재하지 않는 paymentId로 이벤트 발행
+            String payload = EventFixture.paymentCancelCompensationEventJson(
+                    99999L, member.getId(), RECHARGE_AMOUNT, "없는 결제", OffsetDateTime.now());
+            publishRawMessage(payload);
+
+            // then: 재시도 후 DLQ 이동
+            waitForDLQ(RabbitMQQueue.PAYMENT_CANCEL_COMPENSATE_DLQ, 1);
+            assertQueueEmpty(RabbitMQQueue.PAYMENT_CANCEL_COMPENSATE_QUEUE);
+        }
+    }
+
+    @Nested
+    @DisplayName("E2E 체이닝")
+    class EndToEndChainingTest {
+
+        @Test
+        @DisplayName("성공 : compensateCancellationFailure → Outbox → RabbitMQ → Listener → 보상 완료")
+        void shouldCompleteCompensationChain() {
+            // given: 충전 완료
+            String paymentKey = "e2e_pk_" + System.currentTimeMillis();
+            MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
+                    new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
+            mockTossConfirm(paymentKey);
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+
+            Payment payment = paymentRepository.findByPaymentKeyWithMember(paymentKey).orElseThrow();
+            PaymentCancelResponse cancelResponse = PaymentCancelResponseFixture.create(
+                    paymentKey, RECHARGE_AMOUNT, "E2E 보상 테스트");
+
+            // when: compensateCancellationFailure 호출 (보상 트랜잭션 시작점)
+            paymentInternalService.compensateCancellationFailure(
+                    payment, member, cancelResponse, new RuntimeException("DB 실패 시뮬레이션"));
+
+            // then: Outbox PUBLISHED 확인
+            waitForOutboxPublished(payment.getId());
+
+            // then: compensationCompleted 확인
+            waitForCompensationCompleted(payment.getId());
+
+            // then: Wallet 출금 확인
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isZero();
+
+            // then: AssetHistory CANCEL 기록 확인
+            List<AssetHistory> cancelHistories = assetHistoryRepository.findAll().stream()
+                    .filter(h -> h.getCategory() == TransactionCategory.RECHARGE_CANCEL)
+                    .toList();
+            assertThat(cancelHistories).hasSize(1);
+        }
+    }
+
+    // ================= Helper ====================
+
+    private Payment createCanceledPayment() {
+        String paymentKey = "comp_pk_" + System.currentTimeMillis();
+        MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
+                new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
+        mockTossConfirm(paymentKey);
+        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+
+        Payment payment = paymentRepository.findByPaymentKeyWithMember(paymentKey).orElseThrow();
+        payment.cancel("보상 테스트용 취소");
+        paymentRepository.saveAndFlush(payment);
+
+        return payment;
+    }
+
+    private void publishCompensationEvent(Payment payment) {
+        String payload = EventFixture.paymentCancelCompensationEventJson(
+                payment.getId(), member.getId(), RECHARGE_AMOUNT, "보상 테스트", OffsetDateTime.now());
+        publishRawMessage(payload);
+    }
+
+    private void publishRawMessage(String payload) {
+        rabbitTemplate.convertAndSend(
+                AggregateExchangeMapper.getExchange(AggregateType.PAYMENT),
+                EventType.PAYMENT_CANCEL_COMPENSATE.getRoutingKey(),
+                payload,
+                message -> {
+                    message.getMessageProperties().setHeader("eventType",
+                            EventType.PAYMENT_CANCEL_COMPENSATE.getTypeName());
+                    message.getMessageProperties().setHeader("aggregateId", 0L);
+                    return message;
+                }
+        );
+    }
+
+    private void waitForCompensationCompleted(Long paymentId) {
+        await().atMost(ASYNC_TIMEOUT)
+                .pollInterval(Duration.ofMillis(200))
+                .until(() -> {
+                    Payment p = paymentRepository.findById(paymentId).orElseThrow();
+                    return p.isCompensationCompleted();
+                });
+    }
+
+    private void waitForQueueEmpty(String queueName) {
+        await().atMost(ASYNC_TIMEOUT)
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> {
+                    QueueInformation info = rabbitAdmin.getQueueInfo(queueName);
+                    assertThat(info).isNotNull();
+                    assertThat(info.getMessageCount()).isZero();
+                });
+    }
+
+    private void waitForDLQ(String dlqName, int expectedCount) {
+        await().atMost(ASYNC_TIMEOUT)
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> {
+                    QueueInformation dlqInfo = rabbitAdmin.getQueueInfo(dlqName);
+                    assertThat(dlqInfo).isNotNull();
+                    assertThat(dlqInfo.getMessageCount()).isEqualTo(expectedCount);
+                });
+    }
+
+    private void assertQueueEmpty(String queueName) {
+        QueueInformation info = rabbitAdmin.getQueueInfo(queueName);
+        assertThat(info).isNotNull();
+        assertThat(info.getMessageCount()).isZero();
+    }
+
+    private void waitForOutboxPublished(Long paymentId) {
+        await().atMost(ASYNC_TIMEOUT)
+                .untilAsserted(() -> {
+                    List<Outbox> outboxes = outboxRepository
+                            .findByAggregateTypeAndAggregateIdOrderByIdAsc(
+                                    AggregateType.PAYMENT.getTypeName(),
+                                    paymentId,
+                                    PageRequest.of(0, 10)
+                            ).stream()
+                            .filter(o -> o.getEventType().equals(
+                                    EventType.PAYMENT_CANCEL_COMPENSATE.getTypeName()))
+                            .toList();
+                    assertThat(outboxes).isNotEmpty();
+                    assertThat(outboxes).allMatch(o -> o.getStatus() == OutboxStatus.PUBLISHED);
+                });
+    }
+
+    private void mockTossConfirm(String paymentKey) {
+        given(paymentGatewayAdapter.confirmPayment(anyString(), anyString(), anyLong()))
+                .willReturn(TossResponseFixture.createConfirmResponse(paymentKey));
+    }
+}

--- a/src/test/java/com/ureca/snac/integration/PaymentConcurrencyIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/PaymentConcurrencyIntegrationTest.java
@@ -1,0 +1,238 @@
+package com.ureca.snac.integration;
+
+import com.ureca.snac.asset.entity.AssetHistory;
+import com.ureca.snac.asset.entity.TransactionCategory;
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.infra.fixture.TossResponseFixture;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
+import com.ureca.snac.money.dto.MoneyRechargeRequest;
+import com.ureca.snac.money.entity.MoneyRecharge;
+import com.ureca.snac.money.service.MoneyService;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentMethod;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.event.PaymentCancelCompensationEvent;
+import com.ureca.snac.payment.service.PaymentInternalService;
+import com.ureca.snac.payment.service.PaymentService;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
+import com.ureca.snac.wallet.entity.Wallet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 결제 동시성 통합 테스트
+ * Pessimistic Lock, Race Condition 검증
+ */
+@DisplayName("결제 동시성 통합 테스트")
+class PaymentConcurrencyIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MoneyService moneyService;
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Autowired
+    private PaymentInternalService paymentInternalService;
+
+    @MockitoBean
+    private PaymentGatewayAdapter paymentGatewayAdapter;
+
+    private Member member;
+
+    private static final Long RECHARGE_AMOUNT = 10000L;
+    private static final int THREAD_COUNT = 5;
+
+    @BeforeEach
+    void setUpMember() {
+        member = createMemberWithWallet("conc_");
+    }
+
+    @Nested
+    @DisplayName("결제 승인")
+    class ConfirmConcurrencyTest {
+
+        @Test
+        @DisplayName("동시성 : 동일 orderId N건 동시 승인 → Wallet 1회만 증가")
+        void shouldAllowOnlyOneConfirmation() throws InterruptedException {
+            // given
+            MoneyRechargePreparedResponse prepared = prepareRecharge();
+            String paymentKey = "conc_pk_" + System.currentTimeMillis();
+            mockTossConfirm(paymentKey);
+
+            // when: N건 동시 승인
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failCount = new AtomicInteger();
+
+            runConcurrently(() -> {
+                try {
+                    moneyService.processRechargeSuccess(
+                            paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            }, THREAD_COUNT);
+
+            // then: Wallet 잔액 1회만 증가 (핵심 불변식)
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isEqualTo(RECHARGE_AMOUNT);
+
+            // MoneyRecharge 1건만 생성
+            List<MoneyRecharge> recharges = moneyRechargeRepository.findAll();
+            assertThat(recharges).hasSize(1);
+
+            // 전체 = 성공 + 실패 (deposit이 멱등하게 early return하므로 실패 0건일 수 있음)
+            assertThat(successCount.get() + failCount.get()).isEqualTo(THREAD_COUNT);
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 취소")
+    class CancelConcurrencyTest {
+
+        @Test
+        @DisplayName("동시성 : 동일 paymentKey N건 동시 취소 → Wallet 출금 1회만")
+        void shouldAllowOnlyOneCancellation() throws InterruptedException {
+            // given: 충전 완료
+            String paymentKey = "conc_cancel_pk_" + System.currentTimeMillis();
+            prepareAndCompleteRecharge(paymentKey);
+            mockTossCancel(paymentKey);
+
+            // when: N건 동시 취소
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failCount = new AtomicInteger();
+
+            runConcurrently(() -> {
+                try {
+                    paymentService.cancelPayment(paymentKey, "동시 취소 테스트", member.getEmail());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            }, THREAD_COUNT);
+
+            // then: Wallet 잔액 0 (1회만 출금)
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isZero();
+
+            // AssetHistory CANCEL 1건
+            List<AssetHistory> cancelHistories = assetHistoryRepository.findAll().stream()
+                    .filter(h -> h.getCategory() == TransactionCategory.RECHARGE_CANCEL)
+                    .toList();
+            assertThat(cancelHistories).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("보상 처리")
+    class CompensationConcurrencyTest {
+
+        @Test
+        @DisplayName("동시성 : processCompensation N건 동시 호출 → Wallet 출금 1회만")
+        void shouldAllowOnlyOneCompensation() throws InterruptedException {
+            // given: 충전 완료된 결제를 CANCELED 상태로 변경 (토스 취소 성공 상태 시뮬레이션)
+            String paymentKey = "conc_comp_pk_" + System.currentTimeMillis();
+            MoneyRechargePreparedResponse prepared = prepareRecharge();
+            mockTossConfirm(paymentKey);
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+
+            Payment payment = paymentRepository.findByPaymentKeyWithMember(paymentKey).orElseThrow();
+            payment.cancel("보상 테스트용 취소");
+            paymentRepository.saveAndFlush(payment);
+
+            PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                    payment.getId(), member.getId(), RECHARGE_AMOUNT, "보상 테스트", OffsetDateTime.now());
+
+            // when: N건 동시 보상 처리
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failCount = new AtomicInteger();
+
+            runConcurrently(() -> {
+                try {
+                    paymentInternalService.processCompensation(event);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            }, THREAD_COUNT);
+
+            // then: compensationCompleted = true
+            Payment result = paymentRepository.findById(payment.getId()).orElseThrow();
+            assertThat(result.isCompensationCompleted()).isTrue();
+
+            // AssetHistory CANCEL 1건만
+            List<AssetHistory> cancelHistories = assetHistoryRepository.findAll().stream()
+                    .filter(h -> h.getCategory() == TransactionCategory.RECHARGE_CANCEL)
+                    .toList();
+            assertThat(cancelHistories).hasSize(1);
+        }
+    }
+
+    // ================= Helper ====================
+
+    private void runConcurrently(Runnable task, int threadCount) throws InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    latch.await();
+                    task.run();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+        }
+
+        latch.countDown();
+
+        for (Future<?> future : futures) {
+            try {
+                future.get(10, TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException ignored) {
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(15, TimeUnit.SECONDS);
+    }
+
+    private MoneyRechargePreparedResponse prepareRecharge() {
+        return moneyService.prepareRecharge(new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
+    }
+
+    private void prepareAndCompleteRecharge(String paymentKey) {
+        MoneyRechargePreparedResponse prepared = prepareRecharge();
+        mockTossConfirm(paymentKey);
+        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+    }
+
+    private void mockTossConfirm(String paymentKey) {
+        given(paymentGatewayAdapter.confirmPayment(anyString(), anyString(), anyLong()))
+                .willReturn(TossResponseFixture.createConfirmResponse(paymentKey));
+    }
+
+    private void mockTossCancel(String paymentKey) {
+        given(paymentGatewayAdapter.cancelPayment(anyString(), anyString()))
+                .willReturn(PaymentCancelResponseFixture.create(paymentKey, RECHARGE_AMOUNT, "동시 취소 테스트"));
+    }
+}

--- a/src/test/java/com/ureca/snac/integration/PaymentSyncFlowIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/PaymentSyncFlowIntegrationTest.java
@@ -1,0 +1,271 @@
+package com.ureca.snac.integration;
+
+import com.ureca.snac.asset.entity.AssetHistory;
+import com.ureca.snac.asset.entity.TransactionCategory;
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.infra.fixture.TossResponseFixture;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.member.exception.MemberNotFoundException;
+import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
+import com.ureca.snac.money.dto.MoneyRechargeRequest;
+import com.ureca.snac.money.entity.MoneyRecharge;
+import com.ureca.snac.money.service.MoneyService;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.AlreadyUsedRechargeCannotCancelException;
+import com.ureca.snac.payment.exception.PaymentNotFoundException;
+import com.ureca.snac.payment.service.PaymentService;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
+import com.ureca.snac.wallet.entity.Wallet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 결제 동기 플로우 통합 테스트
+ * Controller -> Service -> DB -> External API 동기 플로우
+ */
+@DisplayName("결제 동기 플로우 통합 테스트")
+class PaymentSyncFlowIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MoneyService moneyService;
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @MockitoBean
+    private PaymentGatewayAdapter paymentGatewayAdapter;
+
+    private Member member;
+
+    private static final Long RECHARGE_AMOUNT = 10000L;
+    private static final String PAYMENT_KEY = "toss_pk_sync_";
+
+    @BeforeEach
+    void setUpMember() {
+        member = createMemberWithWallet("sync_");
+    }
+
+    @Nested
+    @DisplayName("충전 준비")
+    class PrepareRechargeTest {
+
+        @Test
+        @DisplayName("성공 : prepareRecharge -> Payment PENDING 생성")
+        void shouldCreatePendingPayment() {
+            // when
+            MoneyRechargePreparedResponse prepared = prepareRecharge();
+
+            // then
+            Payment payment = paymentRepository.findByOrderId(prepared.orderId()).orElseThrow();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+            assertThat(payment.getOrderId()).startsWith("snac_order_");
+            assertThat(prepared.amount()).isEqualTo(RECHARGE_AMOUNT);
+        }
+
+        @Test
+        @DisplayName("실패 : 회원 없음 -> MemberNotFoundException")
+        void shouldThrowWhenMemberNotFound() {
+            // when, then
+            assertThatThrownBy(() ->
+                    moneyService.prepareRecharge(
+                            new MoneyRechargeRequest(RECHARGE_AMOUNT), "nonexistent@snac.com")
+            ).isInstanceOf(MemberNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("충전 성공")
+    class RechargeSuccessTest {
+
+        @Test
+        @DisplayName("성공 : 충전 -> Payment SUCCESS + Wallet 증가 + MoneyRecharge + AssetHistory")
+        void shouldCompleteRechargeSuccessfully() {
+            // given
+            MoneyRechargePreparedResponse prepared = prepareRecharge();
+            String paymentKey = uniquePaymentKey();
+            mockTossConfirm(paymentKey);
+
+            // when
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+
+            // then: Payment SUCCESS
+            Payment payment = paymentRepository.findByOrderId(prepared.orderId()).orElseThrow();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+
+            // then: Wallet 잔액 증가
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isEqualTo(RECHARGE_AMOUNT);
+
+            // then: MoneyRecharge 기록
+            List<MoneyRecharge> recharges = moneyRechargeRepository.findAll();
+            assertThat(recharges).hasSize(1);
+            assertThat(recharges.get(0).getPaidAmountWon()).isEqualTo(RECHARGE_AMOUNT);
+
+            // then: AssetHistory 기록
+            List<AssetHistory> histories = assetHistoryRepository.findAll();
+            assertThat(histories).hasSize(1);
+            assertThat(histories.get(0).getCategory()).isEqualTo(TransactionCategory.RECHARGE);
+        }
+
+        @Test
+        @DisplayName("멱등성 : 동일 orderId 중복 승인 -> 예외 + Wallet 1회만 반영")
+        void shouldRejectDuplicateConfirmation() {
+            // given
+            MoneyRechargePreparedResponse prepared = prepareRecharge();
+            String paymentKey = uniquePaymentKey();
+            mockTossConfirm(paymentKey);
+
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+
+            // when, then: 두 번째 승인 -> 예외
+            assertThatThrownBy(() ->
+                    moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail())
+            ).isInstanceOf(Exception.class);
+
+            // Wallet 잔액 1배만 반영
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isEqualTo(RECHARGE_AMOUNT);
+        }
+
+        @Test
+        @DisplayName("실패 : 회원 없음 -> MemberNotFoundException")
+        void shouldThrowWhenMemberNotFoundOnConfirm() {
+            // given
+            MoneyRechargePreparedResponse prepared = prepareRecharge();
+
+            // when, then
+            assertThatThrownBy(() ->
+                    moneyService.processRechargeSuccess(
+                            uniquePaymentKey(), prepared.orderId(), RECHARGE_AMOUNT, "nonexistent@snac.com")
+            ).isInstanceOf(MemberNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("실패 : Toss 승인 실패 -> Payment PENDING 유지, 취소 미호출")
+        void shouldKeepPendingWhenTossConfirmFails() {
+            // given
+            MoneyRechargePreparedResponse prepared = prepareRecharge();
+            String paymentKey = uniquePaymentKey();
+
+            given(paymentGatewayAdapter.confirmPayment(anyString(), anyString(), anyLong()))
+                    .willThrow(new RuntimeException("Toss 승인 실패"));
+
+            // when, then
+            assertThatThrownBy(() ->
+                    moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail())
+            ).isInstanceOf(RuntimeException.class);
+
+            // Payment PENDING 유지
+            Payment payment = paymentRepository.findByOrderId(prepared.orderId()).orElseThrow();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+
+            // cancel 미호출 (Toss 승인 실패 -> 돈 안 빠짐)
+            verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("취소")
+    class CancelTest {
+
+        @Test
+        @DisplayName("성공 : 취소 -> Payment CANCELED + Wallet 출금 + AssetHistory 2건")
+        void shouldCancelPaymentSuccessfully() {
+            // given: 충전 완료
+            String paymentKey = uniquePaymentKey();
+            prepareAndCompleteRecharge(paymentKey);
+            mockTossCancel(paymentKey);
+
+            // when
+            paymentService.cancelPayment(paymentKey, "고객 요청", member.getEmail());
+
+            // then: Payment CANCELED
+            Payment payment = paymentRepository.findByPaymentKeyWithMember(paymentKey).orElseThrow();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+
+            // then: Wallet 잔액 0
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isZero();
+
+            // then: AssetHistory 2건 (충전 + 취소)
+            List<AssetHistory> histories = assetHistoryRepository.findAll();
+            assertThat(histories).hasSize(2);
+            assertThat(histories)
+                    .extracting(AssetHistory::getCategory)
+                    .containsExactlyInAnyOrder(TransactionCategory.RECHARGE, TransactionCategory.RECHARGE_CANCEL);
+        }
+
+        @Test
+        @DisplayName("실패 : 잔액 부족 -> AlreadyUsedRechargeCannotCancelException")
+        void shouldRejectCancelWhenBalanceInsufficient() {
+            // given: 충전 완료 후 잔액을 임의로 줄여서 잔액 부족 시뮬레이션
+            String paymentKey = uniquePaymentKey();
+            prepareAndCompleteRecharge(paymentKey);
+
+            // Wallet 잔액을 0으로 만들어서 취소 불가 상태 만듦
+            Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            wallet.withdrawMoney(RECHARGE_AMOUNT);
+            walletRepository.saveAndFlush(wallet);
+
+            // when, then
+            assertThatThrownBy(() ->
+                    paymentService.cancelPayment(paymentKey, "고객 요청", member.getEmail())
+            ).isInstanceOf(AlreadyUsedRechargeCannotCancelException.class);
+
+            // Payment SUCCESS 유지
+            Payment payment = paymentRepository.findByPaymentKeyWithMember(paymentKey).orElseThrow();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+        }
+
+        @Test
+        @DisplayName("실패 : 결제 없음 -> PaymentNotFoundException")
+        void shouldThrowWhenPaymentNotFound() {
+            // when, then
+            assertThatThrownBy(() ->
+                    paymentService.cancelPayment("nonexistent_pk", "고객 요청", member.getEmail())
+            ).isInstanceOf(PaymentNotFoundException.class);
+        }
+    }
+
+    // ================= Helper ====================
+
+    private MoneyRechargePreparedResponse prepareRecharge() {
+        return moneyService.prepareRecharge(new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
+    }
+
+    private void prepareAndCompleteRecharge(String paymentKey) {
+        MoneyRechargePreparedResponse prepared = prepareRecharge();
+        mockTossConfirm(paymentKey);
+        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+    }
+
+    private void mockTossConfirm(String paymentKey) {
+        given(paymentGatewayAdapter.confirmPayment(anyString(), anyString(), anyLong()))
+                .willReturn(TossResponseFixture.createConfirmResponse(paymentKey));
+    }
+
+    private void mockTossCancel(String paymentKey) {
+        given(paymentGatewayAdapter.cancelPayment(anyString(), anyString()))
+                .willReturn(PaymentCancelResponseFixture.create(paymentKey, RECHARGE_AMOUNT, "고객 요청"));
+    }
+
+    private String uniquePaymentKey() {
+        return PAYMENT_KEY + System.currentTimeMillis();
+    }
+}

--- a/src/test/java/com/ureca/snac/money/service/MoneyDepositorTest.java
+++ b/src/test/java/com/ureca/snac/money/service/MoneyDepositorTest.java
@@ -1,0 +1,154 @@
+package com.ureca.snac.money.service;
+
+import com.ureca.snac.asset.service.AssetRecorder;
+import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.money.repository.MoneyRechargeRepository;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.repository.PaymentRepository;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.PaymentFixture;
+import com.ureca.snac.wallet.service.WalletService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * MoneyDepositor 단위 테스트 (Spring Support)
+ *
+ * @Retryable AOP 동작 검증을 위해 Spring Context를 로드하지만,
+ * 모든 협력 객체는 Mock으로 대체하여 단위 기능을 검증함.
+ */
+@DisplayName("MoneyDepositor 단위 테스트")
+class MoneyDepositorTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MoneyDepositor moneyDepositor;
+
+    @MockitoBean
+    private PaymentRepository paymentRepository;
+
+    @MockitoBean
+    private MoneyRechargeRepository moneyRechargeRepository;
+
+    @MockitoBean
+    private WalletService walletService;
+
+    @MockitoBean
+    private AssetRecorder assetRecorder;
+
+    private Member member;
+    private Payment payment;
+    private TossConfirmResponse tossConfirmResponse;
+
+    private static final String PAYMENT_KEY = "test_payment_key";
+    private static final Long AMOUNT = 10000L;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMember(1L);
+        payment = PaymentFixture.createPendingPayment(member);
+        tossConfirmResponse = new TossConfirmResponse(
+                PAYMENT_KEY, "카드", OffsetDateTime.now()
+        );
+    }
+
+    @Nested
+    @DisplayName("deposit 메서드")
+    class DepositTest {
+
+        @Nested
+        @DisplayName("재시도 동작")
+        class RetryBehaviorTest {
+
+            @Test
+            @DisplayName("정상 : TransientDataAccessException 발생 시 최대 3회 재시도")
+            void deposit_ShouldRetryOnTransientDataAccessException() {
+                // given: FOR UPDATE 락 조회 시 일시적 DB 오류
+                given(paymentRepository.findByIdForUpdate(any()))
+                        .willThrow(new TransientDataAccessException("Connection timeout") {
+                        });
+
+                // when & then: 예외 발생하며 3회 호출됨
+                assertThatThrownBy(() ->
+                        moneyDepositor.deposit(payment, member, tossConfirmResponse)
+                ).isInstanceOf(TransientDataAccessException.class);
+
+                verify(paymentRepository, times(3)).findByIdForUpdate(any());
+            }
+
+            @Test
+            @DisplayName("정상 : 2회 실패 후 3회차에 성공하면 정상 완료")
+            void deposit_ShouldSucceedOnThirdAttempt() {
+                // given: 2번 실패 후 3번째 성공
+                given(paymentRepository.findByIdForUpdate(any()))
+                        .willThrow(new TransientDataAccessException("Connection timeout") {
+                        })
+                        .willThrow(new TransientDataAccessException("Connection timeout") {
+                        })
+                        .willReturn(Optional.of(payment));
+
+                // MoneyRecharge 저장 mock (null 방지)
+                given(moneyRechargeRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+                given(walletService.depositMoney(anyLong(), anyLong())).willReturn(AMOUNT);
+
+                // when: 예외 없이 완료
+                moneyDepositor.deposit(payment, member, tossConfirmResponse);
+
+                // then: 총 3회 호출
+                verify(paymentRepository, times(3)).findByIdForUpdate(any());
+                verify(walletService, times(1)).depositMoney(member.getId(), AMOUNT);
+            }
+
+            @Test
+            @DisplayName("예외 : 재시도 불가능한 예외는 즉시 전파")
+            void deposit_ShouldNotRetryOnNonRetryableException() {
+                // given: FOR UPDATE 락 조회 시 일반 예외
+                given(paymentRepository.findByIdForUpdate(any()))
+                        .willThrow(new IllegalStateException("Non-retryable error"));
+
+                // when & then: 예외 발생하며 1회만 호출됨
+                assertThatThrownBy(() ->
+                        moneyDepositor.deposit(payment, member, tossConfirmResponse)
+                ).isInstanceOf(IllegalStateException.class);
+
+                verify(paymentRepository, times(1)).findByIdForUpdate(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("멱등성 처리")
+        class IdempotencyTest {
+
+            @Test
+            @DisplayName("정상 : 이미 처리된 충전 요청(SUCCESS 상태)은 재시도 없이 즉시 반환")
+            void deposit_ShouldReturnImmediatelyIfAlreadyProcessed() {
+                // given: FOR UPDATE 락 조회 시 이미 SUCCESS 상태인 Payment 반환
+                Payment successPayment = PaymentFixture.createSuccessPayment(member);
+                given(paymentRepository.findByIdForUpdate(any())).willReturn(Optional.of(successPayment));
+
+                // when: 예외 없이 즉시 반환
+                moneyDepositor.deposit(payment, member, tossConfirmResponse);
+
+                // then: MoneyRecharge 저장 호출 안 됨
+                verify(moneyRechargeRepository, never()).save(any());
+                verify(walletService, never()).depositMoney(anyLong(), anyLong());
+            }
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/money/service/MoneyServiceTest.java
+++ b/src/test/java/com/ureca/snac/money/service/MoneyServiceTest.java
@@ -1,0 +1,363 @@
+package com.ureca.snac.money.service;
+
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.infra.TossErrorCode;
+import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.infra.fixture.TossResponseFixture;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.member.exception.MemberNotFoundException;
+import com.ureca.snac.member.repository.MemberRepository;
+import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
+import com.ureca.snac.money.dto.MoneyRechargeRequest;
+import com.ureca.snac.payment.dto.PaymentCancelResponse;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.event.alert.AutoCancelFailureEvent;
+import com.ureca.snac.payment.exception.PaymentAlreadyProcessedPaymentException;
+import com.ureca.snac.payment.exception.TossInvalidCardInfoException;
+import com.ureca.snac.payment.exception.TossNotEnoughBalanceException;
+import com.ureca.snac.payment.exception.TossRetryableException;
+import com.ureca.snac.payment.service.PaymentService;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
+import com.ureca.snac.support.fixture.PaymentFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * MoneyService 단위 테스트
+ * <p>
+ * 충전 성공 처리 (토스 승인 + DB 처리),Auto-Cancel (토스 성공 후 DB 실패 시 자동 취소)
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MoneyServiceTest 단위 테스트")
+class MoneyServiceTest {
+
+    @InjectMocks
+    private MoneyServiceImpl moneyService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @Mock
+    private PaymentGatewayAdapter paymentGatewayAdapter;
+
+    @Mock
+    private MoneyDepositor moneyDepositor;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private Member member;
+    private Payment pendingPayment;
+    private TossConfirmResponse tossConfirmResponse;
+    private PaymentCancelResponse cancelResponse;
+
+    private static final String ORDER_ID = "snac_order_test_123";
+    private static final String PAYMENT_KEY = "test_payment_key";
+    private static final Long AMOUNT = 10000L;
+    private static final String EMAIL = "test@snac.com";
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMember(1L);
+        pendingPayment = PaymentFixture.builder()
+                .member(member)
+                .orderId(ORDER_ID)
+                .amount(AMOUNT)
+                .build();
+        tossConfirmResponse = TossResponseFixture.createConfirmResponse(PAYMENT_KEY);
+        cancelResponse = PaymentCancelResponseFixture.create(PAYMENT_KEY, AMOUNT, "Auto-cancel");
+    }
+
+    @Nested
+    @DisplayName("prepareRecharge 메서드")
+    class PrepareRechargeTest {
+
+        @Test
+        @DisplayName("성공 : Member 조회 + Payment 생성 + MoneyRechargePreparedResponse 반환")
+        void prepareRecharge_HappyPath() {
+            // given
+            MoneyRechargeRequest request = new MoneyRechargeRequest(AMOUNT);
+            Payment createdPayment = PaymentFixture.builder()
+                    .member(member)
+                    .orderId(ORDER_ID)
+                    .amount(AMOUNT)
+                    .build();
+
+            given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+            given(paymentService.preparePayment(member, AMOUNT)).willReturn(createdPayment);
+
+            // when
+            MoneyRechargePreparedResponse response = moneyService.prepareRecharge(request, EMAIL);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.orderId()).isEqualTo(ORDER_ID);
+            assertThat(response.amount()).isEqualTo(AMOUNT);
+            assertThat(response.customerEmail()).isEqualTo(member.getEmail());
+            verify(paymentService, times(1)).preparePayment(member, AMOUNT);
+        }
+
+        @Test
+        @DisplayName("실패 : 회원 없음 → MemberNotFoundException")
+        void prepareRecharge_MemberNotFound_ThrowsException() {
+            // given
+            MoneyRechargeRequest request = new MoneyRechargeRequest(AMOUNT);
+            given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() -> moneyService.prepareRecharge(request, EMAIL))
+                    .isInstanceOf(MemberNotFoundException.class);
+
+            verify(paymentService, never()).preparePayment(any(), anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("processRechargeSuccess 메서드")
+    class ProcessRechargeSuccessTest {
+
+        @Nested
+        @DisplayName("정상 처리")
+        class HappyPathTest {
+
+            @Test
+            @DisplayName("정상 : 토스 승인 -> DB 처리 모두 성공")
+            void processRechargeSuccess_HappyPath() {
+                // given
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willReturn(pendingPayment);
+                given(paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willReturn(tossConfirmResponse);
+
+                // when
+                moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL);
+
+                // then
+                verify(paymentGatewayAdapter, times(1))
+                        .confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT);
+                verify(moneyDepositor, times(1))
+                        .deposit(any(Payment.class), any(Member.class), any(TossConfirmResponse.class));
+                verify(paymentGatewayAdapter, never())
+                        .cancelPayment(anyString(), anyString());
+            }
+        }
+
+        @Nested
+        @DisplayName("예외 처리")
+        class ExceptionTest {
+
+            @Test
+            @DisplayName("멱등성 : 이미 처리된 Payment는 예외")
+            void processRechargeSuccess_AlreadyProcessed_ThrowsException() {
+                // given : PaymentService가 이미 처리된 Payment에 대해 예외 발생
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willThrow(new PaymentAlreadyProcessedPaymentException());
+
+                // when, then
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(PaymentAlreadyProcessedPaymentException.class);
+
+                // 외부 API 호출 안 함
+                verify(paymentGatewayAdapter, never())
+                        .confirmPayment(anyString(), anyString(), anyLong());
+            }
+
+            @Test
+            @DisplayName("예외 : 다른 회원의 Payment 접근 시 예외")
+            void processRechargeSuccess_WrongOwner_ThrowsException() {
+                // given : PaymentService가 소유자 불일치 시 예외 발생
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willThrow(new IllegalArgumentException("Payment owner mismatch"));
+
+                // when, then
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(IllegalArgumentException.class);
+
+                // 외부 API 호출 안 함
+                verify(paymentGatewayAdapter, never())
+                        .confirmPayment(anyString(), anyString(), anyLong());
+            }
+
+            @Test
+            @DisplayName("예외 : 금액 불일치 시 예외")
+            void processRechargeSuccess_AmountMismatch_ThrowsException() {
+                // given : PaymentService가 금액 불일치 시 예외 발생
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willThrow(new IllegalArgumentException("Amount mismatch"));
+
+                // when, then
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(IllegalArgumentException.class);
+
+                // 외부 API 호출 안 함
+                verify(paymentGatewayAdapter, never())
+                        .confirmPayment(anyString(), anyString(), anyLong());
+            }
+
+            @Test
+            @DisplayName("실패 : 회원 없음 → MemberNotFoundException")
+            void processRechargeSuccess_MemberNotFound_ThrowsException() {
+                // given
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+                // when, then
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(MemberNotFoundException.class);
+
+                verify(paymentService, never()).findAndValidateForConfirmation(anyString(), anyLong(), any());
+                verify(paymentGatewayAdapter, never()).confirmPayment(anyString(), anyString(), anyLong());
+            }
+
+            @Test
+            @DisplayName("예외 : Toss 재시도 가능 에러 시 예외 전파")
+            void shouldPropagateRetryableExceptionWithoutCancel() {
+                // given: Toss에서 일시적 오류 (재시도 실패 후 전파됨)
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willReturn(pendingPayment);
+                given(paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willThrow(new TossRetryableException(TossErrorCode.SERVICE_UNAVAILABLE));
+
+                // when & then: 예외 전파
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(TossRetryableException.class);
+
+                // Toss 승인 실패 → 취소 불필요
+                verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+            }
+        }
+
+        @Nested
+        @DisplayName("Auto-Cancel 동작")
+        class AutoCancelTest {
+
+            @Test
+            @DisplayName("정상 : 내부 DB 실패 시 Auto-Cancel 호출")
+            void processRechargeSuccess_DBFailure_CallsAutoCancel() {
+                // given
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willReturn(pendingPayment);
+                given(paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willReturn(tossConfirmResponse);
+                given(paymentGatewayAdapter.cancelPayment(anyString(), anyString()))
+                        .willReturn(cancelResponse);
+
+                // DB 저장 실패 런타임 예외
+                RuntimeException dbException = new RuntimeException("DB Connection Failed");
+                doThrow(dbException).when(moneyDepositor)
+                        .deposit(any(Payment.class), any(Member.class), any(TossConfirmResponse.class));
+
+                // when, then
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(Exception.class);
+
+                // Auto-Cancel 호출 확인 (Toss 승인 성공 후 DB 실패 → 자동 취소)
+                verify(paymentGatewayAdapter, times(1))
+                        .cancelPayment(eq(PAYMENT_KEY), anyString());
+            }
+
+            @Test
+            @DisplayName("Auto-Cancel 불필요 : Toss 승인 실패(카드 오류) 시")
+            void shouldNotCancelWhenConfirmPaymentFails_InvalidCard() {
+                // given: Toss에서 카드 오류로 승인 거절
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willReturn(pendingPayment);
+                given(paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willThrow(new TossInvalidCardInfoException());
+
+                // when & then: 예외 발생, cancelPayment 호출 안 됨
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(TossInvalidCardInfoException.class);
+
+                // Toss 승인 실패 → 취소 불필요 (돈 안 빠짐)
+                verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+            }
+
+            @Test
+            @DisplayName("Auto-Cancel 불필요 : Toss 승인 실패(잔액 부족) 시")
+            void shouldNotCancelWhenConfirmPaymentFails_NotEnoughBalance() {
+                // given: Toss에서 잔액 부족으로 승인 거절
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willReturn(pendingPayment);
+                given(paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willThrow(new TossNotEnoughBalanceException());
+
+                // when & then: 예외 발생, cancelPayment 호출 안 됨
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(TossNotEnoughBalanceException.class);
+
+                // Toss 승인 실패 → 취소 불필요 (돈 안 빠짐)
+                verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+            }
+
+            @Test
+            @DisplayName("Auto-Cancel 실패 시 AutoCancelFailureEvent 발행")
+            void shouldPublishEventWhenAutoCancelFails() {
+                // given: Toss 승인 성공, DB 저장 실패, Auto-Cancel도 실패
+                given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+                given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member))
+                        .willReturn(pendingPayment);
+                given(paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willReturn(tossConfirmResponse);
+
+                // DB 저장 실패
+                doThrow(new RuntimeException("DB Connection Failed"))
+                        .when(moneyDepositor).deposit(any(), any(), any());
+
+                // Auto-Cancel도 실패
+                given(paymentGatewayAdapter.cancelPayment(anyString(), anyString()))
+                        .willThrow(new TossRetryableException(TossErrorCode.SERVICE_UNAVAILABLE));
+
+                // when & then: 예외 발생
+                assertThatThrownBy(() ->
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, EMAIL)
+                ).isInstanceOf(Exception.class);
+
+                // Critical: Auto-Cancel 실패 → AutoCancelFailureEvent 발행
+                ArgumentCaptor<AutoCancelFailureEvent> eventCaptor =
+                        ArgumentCaptor.forClass(AutoCancelFailureEvent.class);
+                verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+
+                AutoCancelFailureEvent capturedEvent = eventCaptor.getValue();
+                assertThat(capturedEvent.orderId()).isEqualTo(ORDER_ID);
+                assertThat(capturedEvent.amount()).isEqualTo(AMOUNT);
+                assertThat(capturedEvent.paymentKey()).isEqualTo(PAYMENT_KEY);
+            }
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/listener/CriticalPaymentFailureAlertListenerTest.java
+++ b/src/test/java/com/ureca/snac/payment/listener/CriticalPaymentFailureAlertListenerTest.java
@@ -1,0 +1,145 @@
+package com.ureca.snac.payment.listener;
+
+import com.ureca.snac.payment.event.alert.AutoCancelFailureEvent;
+import com.ureca.snac.payment.event.alert.CompensationFailureEvent;
+import com.ureca.snac.payment.service.PaymentAlertService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.verify;
+
+/**
+ * CriticalPaymentFailureAlertListener 단위 테스트
+ * handleCriticalFailure: 치명적 실패 이벤트 처리 및 Slack 알림 발송
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CriticalPaymentFailureAlertListenerTest 단위 테스트")
+class CriticalPaymentFailureAlertListenerTest {
+
+    @InjectMocks
+    private CriticalPaymentFailureAlertListener listener;
+
+    @Mock
+    private PaymentAlertService paymentAlertService;
+
+    private static final Long PAYMENT_ID = 1L;
+    private static final Long MEMBER_ID = 100L;
+    private static final Long AMOUNT = 10000L;
+    private static final String ORDER_ID = "snac_order_test_123";
+    private static final String PAYMENT_KEY = "test_payment_key";
+
+    @Nested
+    @DisplayName("handleCriticalFailure 메서드")
+    class HandleCriticalFailureTest {
+
+        @Nested
+        @DisplayName("AutoCancelFailureEvent 처리")
+        class AutoCancelFailureEventTest {
+
+            @Test
+            @DisplayName("정상 : AutoCancelFailureEvent 수신 시 alertAutoCancelFailure 호출")
+            void handleCriticalFailure_AutoCancelEvent_CallsAlertService() {
+                // given
+                AutoCancelFailureEvent event = new AutoCancelFailureEvent(
+                        PAYMENT_ID,
+                        MEMBER_ID,
+                        AMOUNT,
+                        ORDER_ID,
+                        PAYMENT_KEY,
+                        "DB Connection Failed",
+                        "Toss Cancel API Failed"
+                );
+
+                // when
+                listener.handleCriticalFailure(event);
+
+                // then
+                verify(paymentAlertService).alertAutoCancelFailure(event);
+            }
+
+            @Test
+            @DisplayName("예외 처리 : alertAutoCancelFailure 실패해도 예외 전파 않음")
+            void handleCriticalFailure_AutoCancelEvent_SwallowsException() {
+                // given
+                AutoCancelFailureEvent event = new AutoCancelFailureEvent(
+                        PAYMENT_ID,
+                        MEMBER_ID,
+                        AMOUNT,
+                        ORDER_ID,
+                        PAYMENT_KEY,
+                        "DB Error",
+                        "Cancel Error"
+                );
+                doThrow(new RuntimeException("Slack API Failed"))
+                        .when(paymentAlertService).alertAutoCancelFailure(event);
+
+                // when & then: 예외 발생하지 않음
+                listener.handleCriticalFailure(event);
+
+                // verify: 호출은 됨
+                verify(paymentAlertService).alertAutoCancelFailure(event);
+            }
+        }
+
+        @Nested
+        @DisplayName("CompensationFailureEvent 처리")
+        class CompensationFailureEventTest {
+
+            @Test
+            @DisplayName("정상 : CompensationFailureEvent 수신 시 alertCompensationFailure 호출")
+            void handleCriticalFailure_CompensationEvent_CallsAlertService() {
+                // given
+                CompensationFailureEvent event = new CompensationFailureEvent(
+                        PAYMENT_ID,
+                        MEMBER_ID,
+                        AMOUNT,
+                        ORDER_ID,
+                        PAYMENT_KEY,
+                        "고객 요청 취소",
+                        OffsetDateTime.now(),
+                        "Original DB Error",
+                        "Compensation DB Error"
+                );
+
+                // when
+                listener.handleCriticalFailure(event);
+
+                // then
+                verify(paymentAlertService).alertCompensationFailure(event);
+            }
+
+            @Test
+            @DisplayName("예외 처리 : alertCompensationFailure 실패해도 예외 전파 않음")
+            void handleCriticalFailure_CompensationEvent_SwallowsException() {
+                // given
+                CompensationFailureEvent event = new CompensationFailureEvent(
+                        PAYMENT_ID,
+                        MEMBER_ID,
+                        AMOUNT,
+                        ORDER_ID,
+                        PAYMENT_KEY,
+                        "취소 사유",
+                        OffsetDateTime.now(),
+                        "Original Error",
+                        "Compensation Error"
+                );
+                doThrow(new RuntimeException("Slack API Failed"))
+                        .when(paymentAlertService).alertCompensationFailure(event);
+
+                // when & then: 예외 발생하지 않음
+                listener.handleCriticalFailure(event);
+
+                // verify: 호출은 됨
+                verify(paymentAlertService).alertCompensationFailure(event);
+            }
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/listener/PaymentCancelCompensationListenerTest.java
+++ b/src/test/java/com/ureca/snac/payment/listener/PaymentCancelCompensationListenerTest.java
@@ -1,0 +1,86 @@
+package com.ureca.snac.payment.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ureca.snac.payment.event.PaymentCancelCompensationEvent;
+import com.ureca.snac.payment.service.PaymentInternalService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentCancelCompensationListener 단위 테스트")
+class PaymentCancelCompensationListenerTest {
+
+    @InjectMocks
+    private PaymentCancelCompensationListener listener;
+
+    @Mock
+    private PaymentInternalService paymentInternalService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("성공 : 유효한 JSON -> processCompensation 호출")
+    void shouldCallProcessCompensationForValidJson() throws Exception {
+        // given
+        String payload = "{\"paymentId\":1,\"memberId\":1,\"amount\":10000,\"reason\":\"테스트\",\"canceledAt\":\"2025-01-01T00:00:00+09:00\"}";
+        PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                1L, 1L, 10000L, "테스트", OffsetDateTime.now());
+
+        given(objectMapper.readValue(payload, PaymentCancelCompensationEvent.class))
+                .willReturn(event);
+
+        // when
+        listener.handleCompensationEvent(payload);
+
+        // then
+        verify(paymentInternalService).processCompensation(event);
+    }
+
+    @Test
+    @DisplayName("실패 : 잘못된 JSON -> AmqpRejectAndDontRequeueException")
+    void shouldThrowAmqpRejectForInvalidJson() throws Exception {
+        // given
+        String invalidPayload = "{invalid json}";
+
+        given(objectMapper.readValue(invalidPayload, PaymentCancelCompensationEvent.class))
+                .willThrow(new JsonProcessingException("파싱 실패") {
+                });
+
+        // when, then
+        assertThatThrownBy(() -> listener.handleCompensationEvent(invalidPayload))
+                .isInstanceOf(AmqpRejectAndDontRequeueException.class);
+    }
+
+    @Test
+    @DisplayName("실패 : processCompensation 예외 -> 원본 예외 re-throw")
+    void shouldRethrowExceptionFromProcessCompensation() throws Exception {
+        // given
+        String payload = "{\"paymentId\":1,\"memberId\":1,\"amount\":10000,\"reason\":\"테스트\",\"canceledAt\":\"2025-01-01T00:00:00+09:00\"}";
+        PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                1L, 1L, 10000L, "테스트", OffsetDateTime.now());
+
+        given(objectMapper.readValue(payload, PaymentCancelCompensationEvent.class))
+                .willReturn(event);
+        doThrow(new RuntimeException("DB 연결 실패"))
+                .when(paymentInternalService).processCompensation(event);
+
+        // when, then
+        assertThatThrownBy(() -> listener.handleCompensationEvent(payload))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("DB 연결 실패");
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/service/PaymentAlertServiceTest.java
+++ b/src/test/java/com/ureca/snac/payment/service/PaymentAlertServiceTest.java
@@ -1,0 +1,182 @@
+package com.ureca.snac.payment.service;
+
+import com.ureca.snac.common.notification.SlackNotifier;
+import com.ureca.snac.common.notification.dto.SlackMessage;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.event.alert.AutoCancelFailureEvent;
+import com.ureca.snac.payment.event.alert.CompensationFailureEvent;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.PaymentFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+/**
+ * PaymentAlertService 단위 테스트
+ * alertAutoCancelFailure : Auto-Cancel 실패 시 Slack 알림 발송
+ * alertCompensationFailure : 보상 처리 실패 시 Slack 알림 발송
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentAlertServiceTest 단위 테스트")
+class PaymentAlertServiceTest {
+
+    @InjectMocks
+    private PaymentAlertService paymentAlertService;
+
+    @Mock
+    private SlackNotifier slackNotifier;
+
+    @Nested
+    @DisplayName("alertAutoCancelFailure 메서드")
+    class AlertAutoCancelFailureTest {
+
+        @Test
+        @DisplayName("정상 : Slack 알림 발송")
+        void alertAutoCancelFailure_ShouldSendSlackMessage() {
+            // given
+            AutoCancelFailureEvent event = new AutoCancelFailureEvent(
+                    1L,
+                    100L,
+                    10000L,
+                    "test_order_123",
+                    "test_payment_key",
+                    "DB Connection Failed",
+                    "Toss Cancel API Failed"
+            );
+
+            // when
+            paymentAlertService.alertAutoCancelFailure(event);
+
+            // then
+            ArgumentCaptor<SlackMessage> messageCaptor = ArgumentCaptor.forClass(SlackMessage.class);
+            verify(slackNotifier).sendAsync(messageCaptor.capture());
+
+            SlackMessage capturedMessage = messageCaptor.getValue();
+            assertThat(capturedMessage.text()).contains("CRITICAL");
+        }
+    }
+
+    @Nested
+    @DisplayName("alertCompensationFailure 메서드")
+    class AlertCompensationFailureTest {
+
+        @Test
+        @DisplayName("정상 : Slack 알림 발송")
+        void alertCompensationFailure_ShouldSendSlackMessage() {
+            // given
+            CompensationFailureEvent event = new CompensationFailureEvent(
+                    1L,
+                    100L,
+                    10000L,
+                    "test_order_123",
+                    "test_payment_key",
+                    "고객 요청 취소",
+                    OffsetDateTime.now(),
+                    "Original DB Error",
+                    "Compensation Error"
+            );
+
+            // when
+            paymentAlertService.alertCompensationFailure(event);
+
+            // then
+            ArgumentCaptor<SlackMessage> messageCaptor = ArgumentCaptor.forClass(SlackMessage.class);
+            verify(slackNotifier).sendAsync(messageCaptor.capture());
+
+            SlackMessage capturedMessage = messageCaptor.getValue();
+            assertThat(capturedMessage.text()).contains("CRITICAL");
+            assertThat(capturedMessage.text()).contains("보상");
+        }
+
+        @Test
+        @DisplayName("정상 : 필수 정보 포함 확인")
+        void alertCompensationFailure_ShouldIncludeRequiredInfo() {
+            // given
+            CompensationFailureEvent event = new CompensationFailureEvent(
+                    1L,
+                    100L,
+                    25000L,
+                    "order_compensation_test",
+                    "pk_compensation_test",
+                    "테스트 취소 사유",
+                    OffsetDateTime.now(),
+                    "Unique Original Error",
+                    "Unique Compensation Error"
+            );
+
+            // when
+            paymentAlertService.alertCompensationFailure(event);
+
+            // then
+            verify(slackNotifier).sendAsync(org.mockito.ArgumentMatchers.any(SlackMessage.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("alertReconciliationAutoCanceled 메서드")
+    class AlertReconciliationAutoCanceledTest {
+
+        @Test
+        @DisplayName("성공 : Slack warning 알림 발송")
+        void alertReconciliationAutoCanceled_ShouldSendWarningMessage() {
+            // given
+            Member member = MemberFixture.createMember(1L);
+            Payment payment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .orderId("snac_order_reconciliation_1")
+                    .amount(10000L)
+                    .build();
+
+            // when
+            paymentAlertService.alertReconciliationAutoCanceled(payment, "pk_reconcile_test");
+
+            // then
+            ArgumentCaptor<SlackMessage> messageCaptor = ArgumentCaptor.forClass(SlackMessage.class);
+            verify(slackNotifier).sendAsync(messageCaptor.capture());
+
+            SlackMessage capturedMessage = messageCaptor.getValue();
+            assertThat(capturedMessage.text()).contains("대사");
+        }
+    }
+
+    @Nested
+    @DisplayName("alertReconciliationCancelFailed 메서드")
+    class AlertReconciliationCancelFailedTest {
+
+        @Test
+        @DisplayName("성공 : Slack danger 알림 발송")
+        void alertReconciliationCancelFailed_ShouldSendDangerMessage() {
+            // given
+            Member member = MemberFixture.createMember(1L);
+            Payment payment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .orderId("snac_order_reconciliation_2")
+                    .amount(15000L)
+                    .build();
+
+            // when
+            paymentAlertService.alertReconciliationCancelFailed(
+                    payment, "pk_reconcile_fail", "Toss API Timeout");
+
+            // then
+            ArgumentCaptor<SlackMessage> messageCaptor = ArgumentCaptor.forClass(SlackMessage.class);
+            verify(slackNotifier).sendAsync(messageCaptor.capture());
+
+            SlackMessage capturedMessage = messageCaptor.getValue();
+            assertThat(capturedMessage.text()).contains("CRITICAL");
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/service/PaymentInternalServiceTest.java
+++ b/src/test/java/com/ureca/snac/payment/service/PaymentInternalServiceTest.java
@@ -1,0 +1,242 @@
+package com.ureca.snac.payment.service;
+
+import com.ureca.snac.asset.entity.AssetHistory;
+import com.ureca.snac.asset.entity.TransactionCategory;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.outbox.entity.Outbox;
+import com.ureca.snac.payment.dto.PaymentCancelResponse;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.event.PaymentCancelCompensationEvent;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
+import com.ureca.snac.support.fixture.PaymentFixture;
+import com.ureca.snac.wallet.entity.Wallet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * PaymentInternalService 통합 테스트
+ * <p>
+ * processCancellationInDB : 결제 취소 시 DB 상태 변경 (Payment, Wallet, AssetHistory)
+ * compensateCancellationFailure : 보상 처리 (REQUIRES_NEW 트랜잭션)
+ * processCompensation: 보상 이벤트 처리
+ */
+@DisplayName("PaymentInternalServiceTest 통합 테스트")
+class PaymentInternalServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private PaymentInternalService paymentInternalService;
+
+    private Member member;
+    private Wallet wallet;
+    private static final Long AMOUNT = 10000L;
+    private static final Long INITIAL_BALANCE = 50000L;
+
+    @BeforeEach
+    void setUpMember() {
+        member = memberRepository.save(MemberFixture.builder()
+                .id(null)
+                .email("test_" + System.currentTimeMillis() + "@snac.com")
+                .build());
+        wallet = walletRepository.save(Wallet.create(member));
+        wallet.depositMoney(INITIAL_BALANCE);
+        walletRepository.save(wallet);
+    }
+
+    @Nested
+    @DisplayName("processCancellationInDB 메서드")
+    class ProcessCancellationInDBTest {
+
+        @Test
+        @DisplayName("정상 : Payment 취소 + Wallet 출금 + AssetHistory 기록")
+        void processCancellationInDB_HappyPath() {
+            // given
+            Payment payment = paymentRepository.save(PaymentFixture.builder()
+                    .id(null)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.SUCCESS)
+                    .paymentKey("test_cancel_happy_" + System.currentTimeMillis())
+                    .build());
+
+            PaymentCancelResponse cancelResponse = PaymentCancelResponseFixture.create(
+                    payment.getPaymentKey(), AMOUNT, "고객 요청");
+
+            // when
+            paymentInternalService.processCancellationInDB(payment, member, cancelResponse);
+
+            // then: Payment 상태 변경 확인
+            Payment foundPayment = paymentRepository.findById(payment.getId()).orElseThrow();
+            assertThat(foundPayment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+
+            // then: Wallet 잔액 출금 확인
+            Wallet foundWallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(foundWallet.getMoneyBalance()).isEqualTo(INITIAL_BALANCE - AMOUNT);
+
+            // then: AssetHistory 기록 확인
+            List<AssetHistory> histories = assetHistoryRepository.findAll();
+            assertThat(histories).isNotEmpty();
+            assertThat(histories.stream()
+                    .anyMatch(h -> h.getCategory() == TransactionCategory.RECHARGE_CANCEL))
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("compensateCancellationFailure 메서드")
+    class CompensateCancellationFailureTest {
+
+        @Test
+        @DisplayName("정상 : REQUIRES_NEW 트랜잭션으로 Outbox 이벤트 저장")
+        void compensateCancellationFailure_ShouldPersistOutboxInSeparateTransaction() {
+            // given
+            Payment payment = paymentRepository.save(PaymentFixture.builder()
+                    .id(null)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.SUCCESS)
+                    .paymentKey("test_compensate_" + System.currentTimeMillis())
+                    .build());
+
+            PaymentCancelResponse cancelResponse = PaymentCancelResponseFixture.create(
+                    payment.getPaymentKey(), AMOUNT, "Test cancel");
+
+            Exception originalError = new RuntimeException("DB failure");
+
+            // when
+            paymentInternalService.compensateCancellationFailure(
+                    payment, member, cancelResponse, originalError);
+
+            // then: Payment 상태 CANCELED로 변경
+            Payment foundPayment = paymentRepository.findById(payment.getId()).orElseThrow();
+            assertThat(foundPayment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+
+            // then: Outbox 이벤트 저장
+            List<Outbox> outboxes = outboxRepository.findAll();
+            assertThat(outboxes).isNotEmpty();
+            assertThat(outboxes.stream()
+                    .anyMatch(o -> o.getEventType().contains("PaymentCancelCompensate")))
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("정상 : Outer 트랜잭션 롤백과 무관하게 보상 이벤트 커밋")
+        void compensateCancellationFailure_ShouldCommitIndependentlyOfOuterTransaction() {
+            // given
+            Payment payment = paymentRepository.save(PaymentFixture.builder()
+                    .id(null)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.SUCCESS)
+                    .paymentKey("test_outer_rollback_" + System.currentTimeMillis())
+                    .build());
+
+            PaymentCancelResponse cancelResponse = PaymentCancelResponseFixture.create(
+                    payment.getPaymentKey(), AMOUNT, "Test cancel outer");
+
+            Exception originalError = new RuntimeException("DB failure");
+
+            // when
+            paymentInternalService.compensateCancellationFailure(
+                    payment, member, cancelResponse, originalError);
+
+            // then: Outbox 이벤트가 실제로 커밋됨
+            List<Outbox> outboxes = outboxRepository.findAll();
+            assertThat(outboxes).isNotEmpty();
+            assertThat(outboxes.stream()
+                    .anyMatch(o -> o.getEventType().contains("PaymentCancelCompensate")))
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("processCompensation 메서드")
+    class ProcessCompensationTest {
+
+        @Test
+        @DisplayName("정상 : Wallet 출금 + AssetHistory 기록")
+        void processCompensation_HappyPath() {
+            // given
+            Payment payment = paymentRepository.save(PaymentFixture.builder()
+                    .id(null)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.CANCELED)
+                    .paymentKey("test_process_comp_" + System.currentTimeMillis())
+                    .build());
+
+            PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                    payment.getId(),
+                    member.getId(),
+                    AMOUNT,
+                    "보상 처리",
+                    OffsetDateTime.now()
+            );
+
+            // when
+            paymentInternalService.processCompensation(event);
+
+            // then: Wallet 잔액 출금 확인
+            Wallet foundWallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(foundWallet.getMoneyBalance()).isEqualTo(INITIAL_BALANCE - AMOUNT);
+
+            // then: AssetHistory 기록 확인
+            List<AssetHistory> histories = assetHistoryRepository.findAll();
+            assertThat(histories).isNotEmpty();
+            assertThat(histories.stream()
+                    .anyMatch(h -> h.getCategory() == TransactionCategory.RECHARGE_CANCEL))
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("processCompensation 멱등성")
+    class ProcessCompensationIdempotencyTest {
+
+        @Test
+        @DisplayName("멱등성 : 동일 이벤트 2회 처리 시 Wallet 1회만 출금")
+        void processCompensation_CalledTwice_WithdrawsOnlyOnce() {
+            // given
+            Payment payment = paymentRepository.save(PaymentFixture.builder()
+                    .id(null)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.CANCELED)
+                    .paymentKey("test_idempotent_" + System.currentTimeMillis())
+                    .build());
+
+            PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                    payment.getId(),
+                    member.getId(),
+                    AMOUNT,
+                    "보상 처리",
+                    OffsetDateTime.now()
+            );
+
+            // when: 동일 이벤트 2회 처리
+            paymentInternalService.processCompensation(event);
+            paymentInternalService.processCompensation(event);
+
+            // then: Wallet 잔액 1회만 출금
+            Wallet foundWallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+            assertThat(foundWallet.getMoneyBalance()).isEqualTo(INITIAL_BALANCE - AMOUNT);
+
+            // then: AssetHistory 1건만 기록
+            List<AssetHistory> histories = assetHistoryRepository.findAll();
+            long cancelCount = histories.stream()
+                    .filter(h -> h.getCategory() == TransactionCategory.RECHARGE_CANCEL)
+                    .count();
+            assertThat(cancelCount).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/service/PaymentInternalServiceUnitTest.java
+++ b/src/test/java/com/ureca/snac/payment/service/PaymentInternalServiceUnitTest.java
@@ -1,0 +1,307 @@
+package com.ureca.snac.payment.service;
+
+import com.ureca.snac.asset.service.AssetRecorder;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.member.repository.MemberRepository;
+import com.ureca.snac.payment.dto.PaymentCancelResponse;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.event.PaymentCancelCompensationEvent;
+import com.ureca.snac.payment.event.alert.CompensationFailureEvent;
+import com.ureca.snac.payment.repository.PaymentRepository;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.PaymentFixture;
+import com.ureca.snac.wallet.service.WalletService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+/**
+ * PaymentInternalService 단위 테스트
+ * compensateCancellationFailure : 보상 처리 실패 시 CompensationFailureEvent 발행
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentInternalServiceUnitTest 단위 테스트")
+class PaymentInternalServiceUnitTest {
+
+    @InjectMocks
+    private PaymentInternalService paymentInternalService;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private WalletService walletService;
+
+    @Mock
+    private AssetRecorder assetRecorder;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private Member member;
+    private Payment payment;
+    private PaymentCancelResponse cancelResponse;
+    private static final Long AMOUNT = 10000L;
+    private static final String PAYMENT_KEY = "test_payment_key";
+    private static final String ORDER_ID = "snac_order_test_123";
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMember(1L);
+        payment = PaymentFixture.builder()
+                .id(1L)
+                .member(member)
+                .orderId(ORDER_ID)
+                .amount(AMOUNT)
+                .paymentKey(PAYMENT_KEY)
+                .build();
+        cancelResponse = new PaymentCancelResponse(
+                PAYMENT_KEY,
+                AMOUNT,
+                OffsetDateTime.now(),
+                "테스트 취소"
+        );
+    }
+
+    @Nested
+    @DisplayName("compensateCancellationFailure 메서드")
+    class CompensateCancellationFailureTest {
+
+        @Test
+        @DisplayName("보상 처리 실패 시 CompensationFailureEvent 발행")
+        void compensateCancellationFailure_WhenFails_ShouldPublishEvent() {
+            // given: Payment 조회 시 예외 발생하도록 설정
+            Exception originalError = new RuntimeException("Original DB Error");
+            given(paymentRepository.findById(anyLong()))
+                    .willThrow(new RuntimeException("Compensation DB Error"));
+
+            // when
+            paymentInternalService.compensateCancellationFailure(
+                    payment, member, cancelResponse, originalError);
+
+            // then: CompensationFailureEvent 발행 확인
+            ArgumentCaptor<CompensationFailureEvent> eventCaptor =
+                    ArgumentCaptor.forClass(CompensationFailureEvent.class);
+            verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+
+            CompensationFailureEvent capturedEvent = eventCaptor.getValue();
+            assertThat(capturedEvent.paymentId()).isEqualTo(payment.getId());
+            assertThat(capturedEvent.memberId()).isEqualTo(member.getId());
+            assertThat(capturedEvent.amount()).isEqualTo(AMOUNT);
+            assertThat(capturedEvent.orderId()).isEqualTo(ORDER_ID);
+            assertThat(capturedEvent.paymentKey()).isEqualTo(PAYMENT_KEY);
+            assertThat(capturedEvent.cancelReason()).isEqualTo(cancelResponse.reason());
+            assertThat(capturedEvent.originalErrorMessage()).isEqualTo("Original DB Error");
+            assertThat(capturedEvent.compensationErrorMessage()).isEqualTo("Compensation DB Error");
+        }
+
+        @Test
+        @DisplayName("보상 처리 성공 시 CompensationFailureEvent 미발행")
+        void compensateCancellationFailure_WhenSucceeds_ShouldNotPublishFailureEvent() {
+            // given: 정상 처리되도록 설정
+            Exception originalError = new RuntimeException("Original DB Error");
+            given(paymentRepository.findById(anyLong())).willReturn(Optional.of(payment));
+            given(paymentRepository.save(any(Payment.class))).willReturn(payment);
+
+            // when
+            paymentInternalService.compensateCancellationFailure(
+                    payment, member, cancelResponse, originalError);
+
+            // then: CompensationFailureEvent 미발행, PaymentCancelCompensationEvent만 발행
+            ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+
+            Object capturedEvent = eventCaptor.getValue();
+            assertThat(capturedEvent).isNotInstanceOf(CompensationFailureEvent.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("processCancellationInDB 메서드")
+    class ProcessCancellationInDBTest {
+
+        @Test
+        @DisplayName("성공 : Payment CANCELED + walletService.withdrawMoney + assetRecorder 호출")
+        void processCancellationInDB_HappyPath() {
+            // given
+            Payment successPayment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.SUCCESS)
+                    .paymentKey(PAYMENT_KEY)
+                    .build();
+
+            given(paymentRepository.findByIdForUpdate(1L)).willReturn(Optional.of(successPayment));
+            given(walletService.withdrawMoney(member.getId(), AMOUNT)).willReturn(5000L);
+
+            // when
+            paymentInternalService.processCancellationInDB(successPayment, member, cancelResponse);
+
+            // then
+            assertThat(successPayment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+            verify(walletService, times(1)).withdrawMoney(member.getId(), AMOUNT);
+            verify(assetRecorder, times(1)).recordMoneyRechargeCancel(
+                    member.getId(), 1L, AMOUNT, 5000L);
+        }
+
+        @Test
+        @DisplayName("멱등성 : 이미 CANCELED -> walletService 미호출, 조기 종료")
+        void processCancellationInDB_AlreadyCanceled_SkipsProcessing() {
+            // given
+            Payment canceledPayment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.CANCELED)
+                    .paymentKey(PAYMENT_KEY)
+                    .build();
+
+            given(paymentRepository.findByIdForUpdate(1L)).willReturn(Optional.of(canceledPayment));
+
+            // when
+            paymentInternalService.processCancellationInDB(canceledPayment, member, cancelResponse);
+
+            // then
+            verify(walletService, never()).withdrawMoney(anyLong(), anyLong());
+            verify(assetRecorder, never()).recordMoneyRechargeCancel(anyLong(), anyLong(), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("실패 : Payment 없음 -> PaymentNotFoundException")
+        void processCancellationInDB_PaymentNotFound_ThrowsException() {
+            // given
+            given(paymentRepository.findByIdForUpdate(1L)).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() ->
+                    paymentInternalService.processCancellationInDB(payment, member, cancelResponse)
+            ).isInstanceOf(com.ureca.snac.payment.exception.PaymentNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("processCompensation 메서드")
+    class ProcessCompensationTest {
+
+        @Test
+        @DisplayName("멱등성 : 이미 보상 완료된 Payment -> withdrawMoney 호출 안 함")
+        void processCompensation_AlreadyCompleted_SkipsWithdraw() {
+            // given: compensationCompleted = true인 Payment
+            Payment completedPayment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.CANCELED)
+                    .paymentKey(PAYMENT_KEY)
+                    .build();
+            completedPayment.markCompensationCompleted();
+
+            given(paymentRepository.findByIdForUpdate(1L))
+                    .willReturn(Optional.of(completedPayment));
+
+            PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                    1L, member.getId(), AMOUNT, "보상 처리", OffsetDateTime.now()
+            );
+
+            // when
+            paymentInternalService.processCompensation(event);
+
+            // then: withdrawMoney 호출 안 함
+            verify(walletService, never()).withdrawMoney(anyLong(), anyLong());
+            verify(assetRecorder, never()).recordMoneyRechargeCancel(anyLong(), anyLong(), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("성공 : Payment 조회 + withdrawMoney + recordMoneyRechargeCancel + markCompensationCompleted")
+        void processCompensation_HappyPath() {
+            // given
+            Payment canceledPayment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.CANCELED)
+                    .paymentKey(PAYMENT_KEY)
+                    .build();
+
+            given(paymentRepository.findByIdForUpdate(1L)).willReturn(Optional.of(canceledPayment));
+            given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+            given(walletService.withdrawMoney(member.getId(), AMOUNT)).willReturn(5000L);
+
+            PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                    1L, member.getId(), AMOUNT, "보상 처리", OffsetDateTime.now()
+            );
+
+            // when
+            paymentInternalService.processCompensation(event);
+
+            // then
+            verify(walletService, times(1)).withdrawMoney(member.getId(), AMOUNT);
+            verify(assetRecorder, times(1)).recordMoneyRechargeCancel(
+                    member.getId(), 1L, AMOUNT, 5000L);
+            assertThat(canceledPayment.isCompensationCompleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("실패 : Payment 없음 -> PaymentNotFoundException")
+        void processCompensation_PaymentNotFound_ThrowsException() {
+            // given
+            given(paymentRepository.findByIdForUpdate(1L)).willReturn(Optional.empty());
+
+            PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                    1L, member.getId(), AMOUNT, "보상 처리", OffsetDateTime.now()
+            );
+
+            // when, then
+            assertThatThrownBy(() -> paymentInternalService.processCompensation(event))
+                    .isInstanceOf(com.ureca.snac.payment.exception.PaymentNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("실패 : Member 없음 -> MemberNotFoundException")
+        void processCompensation_MemberNotFound_ThrowsException() {
+            // given
+            Payment canceledPayment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .amount(AMOUNT)
+                    .status(PaymentStatus.CANCELED)
+                    .paymentKey(PAYMENT_KEY)
+                    .build();
+
+            given(paymentRepository.findByIdForUpdate(1L)).willReturn(Optional.of(canceledPayment));
+            given(memberRepository.findById(member.getId())).willReturn(Optional.empty());
+
+            PaymentCancelCompensationEvent event = new PaymentCancelCompensationEvent(
+                    1L, member.getId(), AMOUNT, "보상 처리", OffsetDateTime.now()
+            );
+
+            // when, then
+            assertThatThrownBy(() -> paymentInternalService.processCompensation(event))
+                    .isInstanceOf(com.ureca.snac.member.exception.MemberNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/ureca/snac/payment/service/PaymentServiceTest.java
@@ -1,0 +1,279 @@
+package com.ureca.snac.payment.service;
+
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.member.exception.MemberNotFoundException;
+import com.ureca.snac.member.repository.MemberRepository;
+import com.ureca.snac.payment.dto.PaymentCancelResponse;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.PaymentNotFoundException;
+import com.ureca.snac.payment.repository.PaymentRepository;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
+import com.ureca.snac.support.fixture.PaymentFixture;
+import com.ureca.snac.wallet.service.WalletService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * PaymentService 단위 테스트
+ * preparePayment: 결제 준비 (Payment 생성)
+ * cancelPayment: 결제 취소 (토스 API + DB 처리 + 보상 로직)
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentServiceTest 단위 테스트")
+class PaymentServiceTest {
+
+    @InjectMocks
+    private PaymentServiceImpl paymentService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentGatewayAdapter paymentGatewayAdapter;
+
+    @Mock
+    private PaymentInternalService paymentInternalService;
+
+    @Mock
+    private WalletService walletService;
+
+    private Member member;
+    private Payment successPayment;
+    private PaymentCancelResponse cancelResponse;
+
+    private static final String PAYMENT_KEY = "test_payment_key";
+    private static final String ORDER_ID = "snac_order_test_123";
+    private static final Long AMOUNT = 10000L;
+    private static final String EMAIL = "test@snac.com";
+    private static final String CANCEL_REASON = "고객 요청";
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMember(1L);
+        successPayment = PaymentFixture.createSuccessPayment(member);
+        cancelResponse = PaymentCancelResponseFixture.create(PAYMENT_KEY, AMOUNT, CANCEL_REASON);
+    }
+
+    @Nested
+    @DisplayName("preparePayment 메서드")
+    class PreparePaymentTest {
+
+        @Test
+        @DisplayName("정상 : Payment 생성 후 저장")
+        void preparePayment_HappyPath() {
+            // given
+            Payment expectedPayment = PaymentFixture.builder()
+                    .member(member)
+                    .amount(AMOUNT)
+                    .build();
+            given(paymentRepository.save(any(Payment.class))).willReturn(expectedPayment);
+
+            // when
+            Payment result = paymentService.preparePayment(member, AMOUNT);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getAmount()).isEqualTo(AMOUNT);
+            verify(paymentRepository, times(1)).save(any(Payment.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelPayment 메서드")
+    class CancelPaymentTest {
+
+        @Test
+        @DisplayName("정상 : 토스 취소 -> DB 처리 모두 성공")
+        void cancelPayment_HappyPath() {
+            // given
+            given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+            given(paymentRepository.findByPaymentKeyWithMember(PAYMENT_KEY))
+                    .willReturn(Optional.of(successPayment));
+            given(walletService.getMoneyBalance(member.getId())).willReturn(AMOUNT);
+            given(paymentGatewayAdapter.cancelPayment(PAYMENT_KEY, CANCEL_REASON))
+                    .willReturn(cancelResponse);
+
+            // when
+            paymentService.cancelPayment(PAYMENT_KEY, CANCEL_REASON, EMAIL);
+
+            // then
+            verify(paymentGatewayAdapter, times(1))
+                    .cancelPayment(PAYMENT_KEY, CANCEL_REASON);
+            verify(paymentInternalService, times(1))
+                    .processCancellationInDB(any(Payment.class), any(Member.class), any(PaymentCancelResponse.class));
+        }
+
+        @Test
+        @DisplayName("보상 처리 : 토스 취소 성공 + DB 실패 시 보상 처리 호출")
+        void cancelPayment_DBFailure_CompensationTriggered() {
+            // given
+            given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+            given(paymentRepository.findByPaymentKeyWithMember(PAYMENT_KEY))
+                    .willReturn(Optional.of(successPayment));
+            given(walletService.getMoneyBalance(member.getId())).willReturn(AMOUNT);
+            given(paymentGatewayAdapter.cancelPayment(PAYMENT_KEY, CANCEL_REASON))
+                    .willReturn(cancelResponse);
+
+            RuntimeException dbException = new RuntimeException("DB Connection Failed");
+            doThrow(dbException).when(paymentInternalService)
+                    .processCancellationInDB(any(Payment.class), any(Member.class), any(PaymentCancelResponse.class));
+
+            // when, then
+            assertThatThrownBy(() ->
+                    paymentService.cancelPayment(PAYMENT_KEY, CANCEL_REASON, EMAIL)
+            ).isInstanceOf(RuntimeException.class)
+                    .hasMessage("DB Connection Failed");
+
+            // 보상 처리 호출 확인 (PaymentInternalService로 위임)
+            verify(paymentInternalService, times(1))
+                    .compensateCancellationFailure(
+                            any(Payment.class),
+                            any(Member.class),
+                            any(PaymentCancelResponse.class),
+                            any(Exception.class)
+                    );
+        }
+
+        @Test
+        @DisplayName("예외 : 잔액 부족 시 취소 불가")
+        void cancelPayment_InsufficientBalance_ThrowsException() {
+            // given : 잔액이 결제 금액보다 적음
+            given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+            given(paymentRepository.findByPaymentKeyWithMember(PAYMENT_KEY))
+                    .willReturn(Optional.of(successPayment));
+            given(walletService.getMoneyBalance(member.getId())).willReturn(1000L); // 부족
+
+            // when, then
+            assertThatThrownBy(() ->
+                    paymentService.cancelPayment(PAYMENT_KEY, CANCEL_REASON, EMAIL)
+            ).isInstanceOf(Exception.class);
+
+            // 외부 API 호출 안 함
+            verify(paymentGatewayAdapter, never())
+                    .cancelPayment(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("실패 : 회원 없음 -> MemberNotFoundException")
+        void cancelPayment_MemberNotFound_ThrowsException() {
+            // given
+            given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() ->
+                    paymentService.cancelPayment(PAYMENT_KEY, CANCEL_REASON, EMAIL)
+            ).isInstanceOf(MemberNotFoundException.class);
+
+            verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("실패 : 결제 없음 -> PaymentNotFoundException")
+        void cancelPayment_PaymentNotFound_ThrowsException() {
+            // given
+            given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+            given(paymentRepository.findByPaymentKeyWithMember(PAYMENT_KEY))
+                    .willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() ->
+                    paymentService.cancelPayment(PAYMENT_KEY, CANCEL_REASON, EMAIL)
+            ).isInstanceOf(PaymentNotFoundException.class);
+
+            verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsCanceled 메서드")
+    class MarkAsCanceledTest {
+
+        @Test
+        @DisplayName("성공 : PENDING 결제 -> CANCELED 전환")
+        void markAsCanceled_PendingPayment_TransitionsToCanceled() {
+            // given
+            Payment pendingPayment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .build();
+            given(paymentRepository.findByIdForUpdate(1L)).willReturn(Optional.of(pendingPayment));
+
+            // when
+            paymentService.markAsCanceled(1L, "Auto-cancel");
+
+            // then
+            assertThat(pendingPayment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+            assertThat(pendingPayment.getCancelReason()).isEqualTo("Auto-cancel");
+        }
+
+        @Test
+        @DisplayName("실패 : 결제 없음 -> PaymentNotFoundException")
+        void markAsCanceled_PaymentNotFound_ThrowsException() {
+            // given
+            given(paymentRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() -> paymentService.markAsCanceled(999L, "test"))
+                    .isInstanceOf(PaymentNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAndValidateForConfirmation 메서드")
+    class FindAndValidateForConfirmationTest {
+
+        @Test
+        @DisplayName("성공 : 유효한 orderId + amount + member -> Payment 반환")
+        void findAndValidate_ValidConditions_ReturnsPayment() {
+            // given
+            Payment pendingPayment = PaymentFixture.builder()
+                    .member(member)
+                    .orderId(ORDER_ID)
+                    .amount(AMOUNT)
+                    .build();
+            given(paymentRepository.findByOrderIdWithMemberForUpdate(ORDER_ID))
+                    .willReturn(Optional.of(pendingPayment));
+
+            // when
+            Payment result = paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getOrderId()).isEqualTo(ORDER_ID);
+        }
+
+        @Test
+        @DisplayName("실패 : 주문 없음 -> PaymentNotFoundException")
+        void findAndValidate_OrderNotFound_ThrowsException() {
+            // given
+            given(paymentRepository.findByOrderIdWithMemberForUpdate(ORDER_ID))
+                    .willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() ->
+                    paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member)
+            ).isInstanceOf(PaymentNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/support/IntegrationTestSupport.java
+++ b/src/test/java/com/ureca/snac/support/IntegrationTestSupport.java
@@ -6,8 +6,11 @@ import com.ureca.snac.auth.service.verify.EmailService;
 import com.ureca.snac.auth.service.verify.SnsService;
 import com.ureca.snac.common.notification.SlackNotifier;
 import com.ureca.snac.config.RabbitMQQueue;
+import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.member.repository.SocialLinkRepository;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.wallet.entity.Wallet;
 import com.ureca.snac.money.repository.MoneyRechargeRepository;
 import com.ureca.snac.outbox.repository.OutboxRepository;
 import com.ureca.snac.outbox.scheduler.DlqMonitor;
@@ -183,6 +186,18 @@ public abstract class IntegrationTestSupport {
         outboxRepository.deleteAllInBatch();
 
         memberRepository.deleteAllInBatch();
+    }
+
+    protected Member createMemberWithWallet(String prefix) {
+        String unique = prefix + System.currentTimeMillis();
+        Member member = MemberFixture.builder()
+                .id(null)
+                .email(unique + "@snac.com")
+                .nickname(unique)
+                .build();
+        member = memberRepository.save(member);
+        walletRepository.save(Wallet.create(member));
+        return member;
     }
 
     private void purgeAllQueues() {

--- a/src/test/java/com/ureca/snac/support/fixture/EventFixture.java
+++ b/src/test/java/com/ureca/snac/support/fixture/EventFixture.java
@@ -2,7 +2,7 @@ package com.ureca.snac.support.fixture;
 
 /**
  * 이벤트 JSON Payload 테스트 Fixture
- * SignupBonusListenerTest, WalletCreationListenerTest
+ * SignupBonusListenerTest, WalletCreationListenerTest, PaymentCancelCompensationListenerTest
  */
 public class EventFixture {
 
@@ -12,6 +12,13 @@ public class EventFixture {
 
     public static String walletCreatedEventJson(Long memberId, Long walletId) {
         return String.format("{\"memberId\":%d,\"walletId\":%d}", memberId, walletId);
+    }
+
+    public static String paymentCancelCompensationEventJson(
+            Long paymentId, Long memberId, Long amount, String reason, java.time.OffsetDateTime canceledAt) {
+        return String.format(
+                "{\"paymentId\":%d,\"memberId\":%d,\"amount\":%d,\"reason\":\"%s\",\"canceledAt\":\"%s\"}",
+                paymentId, memberId, amount, reason, canceledAt.toString());
     }
 
     public static String invalidJson() {


### PR DESCRIPTION
## 변경 사항 요약

결제 실패 알림 인프라 및 Auto-Cancel 로직 구현

Closes #19

---

## 주요 변경 사항

- CriticalPaymentFailureEvent sealed interface + AutoCancel/Compensation 이벤트 record
- CriticalPaymentFailureAlertListener 비동기 Slack 알림
- PaymentAlertService 알림 포맷팅
- MoneyServiceImpl Auto-Cancel 로직 완성
- PaymentInternalService CompensationFailureEvent 발행
- 서비스 단위 테스트 및 통합 테스트 추가

> Stacked PR 2/4 — base: `refactor/payment-entity-model`