### PR TITLE
[feat] Retry 인프라 설정 및 Toss 결제 조회 API

### DIFF
--- a/src/main/java/com/ureca/snac/common/notification/SlackNotifier.java
+++ b/src/main/java/com/ureca/snac/common/notification/SlackNotifier.java
@@ -42,8 +42,8 @@ public class SlackNotifier {
     @Async(AsyncConfig.NOTIFICATION_EXECUTOR_NAME)
     @Retryable(
             retryFor = {RestClientException.class},
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 1000)
+            maxAttemptsExpression = "${retry.slack.max-attempts}",
+            backoff = @Backoff(delayExpression = "${retry.slack.delay}")
     )
     public void sendAsync(SlackMessage message) {
         restClient.post()

--- a/src/main/java/com/ureca/snac/config/AsyncConfig.java
+++ b/src/main/java/com/ureca/snac/config/AsyncConfig.java
@@ -1,8 +1,10 @@
 package com.ureca.snac.config;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -15,10 +17,13 @@ import java.util.concurrent.ThreadPoolExecutor;
  * Executor 분리 전략
  * Outbox 이벤트 발행 AFTER_COMMIT 리스너가 사용
  * Slack 알림
+ * TossPaymentsAdapter, MoneyDepositor 재시도 지원
  */
 @Slf4j
 @Configuration
 @EnableAsync
+@EnableRetry
+@EnableConfigurationProperties(RetryProperties.class)
 public class AsyncConfig {
     public static final String EVENT_EXECUTOR_NAME = "eventAsyncExecutor";
     public static final String NOTIFICATION_EXECUTOR_NAME = "notificationAsyncExecutor";

--- a/src/main/java/com/ureca/snac/config/RetryProperties.java
+++ b/src/main/java/com/ureca/snac/config/RetryProperties.java
@@ -1,0 +1,17 @@
+package com.ureca.snac.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "retry")
+public record RetryProperties(
+        RetryPolicy toss,
+        RetryPolicy depositor,
+        RetryPolicy slack
+) {
+    public record RetryPolicy(
+            int maxAttempts,
+            long delay,
+            double multiplier
+    ) {
+    }
+}

--- a/src/main/java/com/ureca/snac/dev/infra/FakePaymentGatewayAdapter.java
+++ b/src/main/java/com/ureca/snac/dev/infra/FakePaymentGatewayAdapter.java
@@ -2,6 +2,7 @@ package com.ureca.snac.dev.infra;
 
 import com.ureca.snac.infra.PaymentGatewayAdapter;
 import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
 import com.ureca.snac.payment.dto.PaymentCancelResponse;
 import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.exception.PaymentNotFoundException;
@@ -44,6 +45,14 @@ public class FakePaymentGatewayAdapter implements PaymentGatewayAdapter {
                 .canceledAt(OffsetDateTime.now())
                 .reason(reason)
                 .build();
+    }
+
+    @Override
+    public TossPaymentInquiryResponse inquirePaymentByOrderId(String orderId) {
+        log.warn("[Fake Adapter] 실제 API 호출 없이 더미 응답 (조회)");
+        return new TossPaymentInquiryResponse(
+                "fake_payment_key", orderId, "DONE", "개발용", 10000L, OffsetDateTime.now()
+        );
     }
 }
 

--- a/src/main/java/com/ureca/snac/infra/PaymentGatewayAdapter.java
+++ b/src/main/java/com/ureca/snac/infra/PaymentGatewayAdapter.java
@@ -1,6 +1,7 @@
 package com.ureca.snac.infra;
 
 import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
 import com.ureca.snac.payment.dto.PaymentCancelResponse;
 
 /**
@@ -27,4 +28,12 @@ public interface PaymentGatewayAdapter {
      * @return 우리 시스템의 표준 결제 취소응답 DTO
      */
     PaymentCancelResponse cancelPayment(String paymentKey, String reason);
+
+    /**
+     * 주문번호로 결제 상태 조회
+     *
+     * @param orderId 우리 시스템의 고유 주문번호
+     * @return 토스페이먼츠 결제 조회 응답
+     */
+    TossPaymentInquiryResponse inquirePaymentByOrderId(String orderId);
 }

--- a/src/main/java/com/ureca/snac/infra/TossPaymentsAdapter.java
+++ b/src/main/java/com/ureca/snac/infra/TossPaymentsAdapter.java
@@ -2,15 +2,25 @@ package com.ureca.snac.infra;
 
 import com.ureca.snac.infra.dto.response.TossCancelResponse;
 import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
 import com.ureca.snac.payment.dto.PaymentCancelResponse;
+import com.ureca.snac.payment.exception.TossRetryableException;
 import com.ureca.snac.payment.mapper.PaymentCancelMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 /**
  * 어댑터 토스페이먼츠 구현체
+ * <p>
+ * confirmPayment에 @Retryable
+ * TossRetryableException 발생 시 최대 3회 재시도
+ * 1초 초기 지연, 2배 증가 (1s -> 2s -> 4s)
  */
+@Slf4j
 @Primary
 @Component
 @RequiredArgsConstructor
@@ -21,18 +31,43 @@ public class TossPaymentsAdapter implements PaymentGatewayAdapter {
     // DTO 매퍼
     private final PaymentCancelMapper paymentCancelMapper;
 
+    @Retryable(
+            retryFor = {TossRetryableException.class},
+            maxAttemptsExpression = "${retry.toss.max-attempts}",
+            backoff = @Backoff(delayExpression = "${retry.toss.delay}",
+                    multiplierExpression = "${retry.toss.multiplier}")
+    )
     @Override
     public TossConfirmResponse confirmPayment(String paymentKey, String orderId, Long amount) {
-        // client에 위임
+        log.debug("[Toss API] confirmPayment 호출. paymentKey: {}, orderId: {}", paymentKey, orderId);
         return tossPaymentsClient.confirmPayment(paymentKey, orderId, amount);
     }
 
+    @Retryable(
+            retryFor = {TossRetryableException.class},
+            maxAttemptsExpression = "${retry.toss.max-attempts}",
+            backoff = @Backoff(delayExpression = "${retry.toss.delay}",
+                    multiplierExpression = "${retry.toss.multiplier}")
+    )
     @Override
     public PaymentCancelResponse cancelPayment(String paymentKey, String reason) {
+        log.debug("[Toss API] cancelPayment 호출. paymentKey: {}", paymentKey);
         // 외부 통신에게 결제 취소 요청
         TossCancelResponse tossResponse = tossPaymentsClient.cancelPayment(paymentKey, reason);
 
         // 응답을 매퍼에 전달해서 서비스 DTO로 변경
         return paymentCancelMapper.toPaymentCancelResponse(tossResponse);
+    }
+
+    @Retryable(
+            retryFor = {TossRetryableException.class},
+            maxAttemptsExpression = "${retry.toss.max-attempts}",
+            backoff = @Backoff(delayExpression = "${retry.toss.delay}",
+                    multiplierExpression = "${retry.toss.multiplier}")
+    )
+    @Override
+    public TossPaymentInquiryResponse inquirePaymentByOrderId(String orderId) {
+        log.debug("[Toss API] inquirePaymentByOrderId 호출. orderId: {}", orderId);
+        return tossPaymentsClient.inquirePaymentByOrderId(orderId);
     }
 }

--- a/src/main/java/com/ureca/snac/infra/TossPaymentsClient.java
+++ b/src/main/java/com/ureca/snac/infra/TossPaymentsClient.java
@@ -4,6 +4,7 @@ import com.ureca.snac.infra.dto.request.TossCancelRequest;
 import com.ureca.snac.infra.dto.request.TossConfirmRequest;
 import com.ureca.snac.infra.dto.response.TossCancelResponse;
 import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -65,5 +66,20 @@ public class TossPaymentsClient {
                 .body(request)
                 .retrieve()
                 .body(TossCancelResponse.class);
+    }
+
+    /**
+     * 주문번호로 결제 정보 조회 API 호출
+     *
+     * @param orderId 우리 시스템의 주문번호
+     * @return 토스페이먼츠 결제 조회 응답
+     */
+    public TossPaymentInquiryResponse inquirePaymentByOrderId(String orderId) {
+        log.info("[외부 API] 토스 페이먼츠 결제 조회 API 호출 시작. 주문번호 : {}", orderId);
+
+        return tossPaymentsRestClient.get()
+                .uri("/v1/payments/orders/{orderId}", orderId)
+                .retrieve()
+                .body(TossPaymentInquiryResponse.class);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -237,3 +237,22 @@ rabbitmq:
       initial-interval: ${RABBITMQ_LISTENER_INITIAL_INTERVAL}
       multiplier: ${RABBITMQ_LISTENER_MULTIPLIER}
       max-interval: ${RABBITMQ_LISTENER_MAX_INTERVAL}
+
+reconciliation:
+  scheduler:
+    cron: ${RECONCILIATION_CRON}
+    stale-threshold-minutes: ${RECONCILIATION_STALE_THRESHOLD}
+    batch-size: ${RECONCILIATION_BATCH_SIZE}
+
+retry:
+  toss:
+    max-attempts: ${RETRY_TOSS_MAX_ATTEMPTS}
+    delay: ${RETRY_TOSS_DELAY}
+    multiplier: ${RETRY_TOSS_MULTIPLIER}
+  depositor:
+    max-attempts: ${RETRY_DEPOSITOR_MAX_ATTEMPTS}
+    delay: ${RETRY_DEPOSITOR_DELAY}
+    multiplier: ${RETRY_DEPOSITOR_MULTIPLIER}
+  slack:
+    max-attempts: ${RETRY_SLACK_MAX_ATTEMPTS}
+    delay: ${RETRY_SLACK_DELAY}

--- a/src/test/java/com/ureca/snac/infra/TossErrorCodeTest.java
+++ b/src/test/java/com/ureca/snac/infra/TossErrorCodeTest.java
@@ -1,0 +1,60 @@
+package com.ureca.snac.infra;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TossErrorCode 단위 테스트")
+class TossErrorCodeTest {
+
+    @Nested
+    @DisplayName("fromCode 메서드")
+    class FromCodeTest {
+
+        @Test
+        @DisplayName("성공 : SERVICE_UNAVAILABLE 코드 -> retryable=true")
+        void fromCode_ServiceUnavailable_ReturnsRetryable() {
+            TossErrorCode result = TossErrorCode.fromCode("SERVICE_UNAVAILABLE");
+
+            assertThat(result).isEqualTo(TossErrorCode.SERVICE_UNAVAILABLE);
+            assertThat(result.isRetryable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 : INVALID_CARD_NUMBER -> retryable=false")
+        void fromCode_InvalidCardNumber_ReturnsNonRetryable() {
+            TossErrorCode result = TossErrorCode.fromCode("INVALID_CARD_NUMBER");
+
+            assertThat(result).isEqualTo(TossErrorCode.INVALID_CARD_NUMBER);
+            assertThat(result.isRetryable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공 : ALREADY_PROCESSED_PAYMENT")
+        void fromCode_AlreadyProcessedPayment() {
+            TossErrorCode result = TossErrorCode.fromCode("ALREADY_PROCESSED_PAYMENT");
+
+            assertThat(result).isEqualTo(TossErrorCode.ALREADY_PROCESSED_PAYMENT);
+            assertThat(result.isRetryable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공 : 알 수 없는 코드 -> UNKNOWN (retryable=true)")
+        void fromCode_UnknownCode_ReturnsUnknown() {
+            TossErrorCode result = TossErrorCode.fromCode("COMPLETELY_UNKNOWN_CODE");
+
+            assertThat(result).isEqualTo(TossErrorCode.UNKNOWN);
+            assertThat(result.isRetryable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 : null 입력 -> UNKNOWN")
+        void fromCode_NullInput_ReturnsUnknown() {
+            TossErrorCode result = TossErrorCode.fromCode(null);
+
+            assertThat(result).isEqualTo(TossErrorCode.UNKNOWN);
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/infra/TossPaymentsAdapterTest.java
+++ b/src/test/java/com/ureca/snac/infra/TossPaymentsAdapterTest.java
@@ -1,0 +1,225 @@
+package com.ureca.snac.infra;
+
+import com.ureca.snac.infra.dto.response.TossCancelResponse;
+import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
+import com.ureca.snac.infra.fixture.TossResponseFixture;
+import com.ureca.snac.payment.dto.PaymentCancelResponse;
+import com.ureca.snac.payment.exception.TossRetryableException;
+import com.ureca.snac.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * TossPaymentsAdapter 단위 테스트
+ * <p>
+ * confirmPayment: 결제 승인 (@Retryable 동작 검증)
+ * cancelPayment: 결제 취소 (@Retryable 동작 검증)
+ */
+@DisplayName("TossPaymentsAdapterTest 단위 테스트")
+class TossPaymentsAdapterTest extends IntegrationTestSupport {
+
+    @Autowired
+    private PaymentGatewayAdapter paymentGatewayAdapter;
+
+    @MockitoBean
+    private TossPaymentsClient tossPaymentsClient;
+
+    private static final String PAYMENT_KEY = "test_payment_key";
+    private static final String ORDER_ID = "snac_order_test_123";
+    private static final Long AMOUNT = 10000L;
+
+    @Nested
+    @DisplayName("confirmPayment 메서드")
+    class ConfirmPaymentTest {
+
+        @Nested
+        @DisplayName("재시도 동작")
+        class RetryBehaviorTest {
+
+            @Test
+            @DisplayName("정상 : TossRetryableException 발생 시 최대 3회 재시도")
+            void confirmPayment_ShouldRetryOnTossRetryableException() {
+                // given: 모든 호출에서 TossRetryableException 발생
+                given(tossPaymentsClient.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willThrow(new TossRetryableException(TossErrorCode.SERVICE_UNAVAILABLE));
+
+                // when & then: 예외 발생하며 3회 호출됨
+                assertThatThrownBy(() ->
+                        paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT)
+                ).isInstanceOf(TossRetryableException.class);
+
+                verify(tossPaymentsClient, times(3)).confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT);
+            }
+
+            @Test
+            @DisplayName("정상 : 2회 실패 후 3회차에 성공하면 정상 응답 반환")
+            void confirmPayment_ShouldSucceedOnThirdAttempt() {
+                // given: 2번 실패 후 3번째 성공
+                TossConfirmResponse successResponse = TossResponseFixture.createConfirmResponse(PAYMENT_KEY);
+
+                given(tossPaymentsClient.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willThrow(new TossRetryableException(TossErrorCode.PROVIDER_ERROR))
+                        .willThrow(new TossRetryableException(TossErrorCode.PROVIDER_ERROR))
+                        .willReturn(successResponse);
+
+                // when
+                TossConfirmResponse response = paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT);
+
+                // then: 성공 응답 반환, 총 3회 호출
+                assertThat(response).isEqualTo(successResponse);
+                verify(tossPaymentsClient, times(3)).confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT);
+            }
+
+            @Test
+            @DisplayName("예외 : 재시도 불가능한 예외는 즉시 전파")
+            void confirmPayment_ShouldNotRetryOnNonRetryableException() {
+                // given: RuntimeException은 재시도 대상이 아님
+                given(tossPaymentsClient.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
+                        .willThrow(new RuntimeException("Non-retryable error"));
+
+                // when & then: 예외 발생하며 1회만 호출됨
+                assertThatThrownBy(() ->
+                        paymentGatewayAdapter.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT)
+                ).isInstanceOf(RuntimeException.class);
+
+                verify(tossPaymentsClient, times(1)).confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelPayment 메서드")
+    class CancelPaymentTest {
+
+        private static final String CANCEL_REASON = "Auto-cancel: DB 처리 실패";
+
+        @Nested
+        @DisplayName("재시도 동작")
+        class RetryBehaviorTest {
+
+            @Test
+            @DisplayName("정상 : TossRetryableException 발생 시 최대 3회 재시도")
+            void cancelPayment_ShouldRetryOnTossRetryableException() {
+                // given: 모든 호출에서 TossRetryableException 발생
+                given(tossPaymentsClient.cancelPayment(PAYMENT_KEY, CANCEL_REASON))
+                        .willThrow(new TossRetryableException(TossErrorCode.SERVICE_UNAVAILABLE));
+
+                // when & then: 예외 발생하며 3회 호출됨
+                assertThatThrownBy(() ->
+                        paymentGatewayAdapter.cancelPayment(PAYMENT_KEY, CANCEL_REASON)
+                ).isInstanceOf(TossRetryableException.class);
+
+                verify(tossPaymentsClient, times(3)).cancelPayment(PAYMENT_KEY, CANCEL_REASON);
+            }
+
+            @Test
+            @DisplayName("정상 : 2회 실패 후 3회차에 성공하면 정상 응답 반환")
+            void cancelPayment_ShouldSucceedOnThirdAttempt() {
+                // given: 2번 실패 후 3번째 성공
+                TossCancelResponse tossCancelResponse = TossResponseFixture.createCancelResponse(
+                        PAYMENT_KEY, AMOUNT, CANCEL_REASON);
+
+                given(tossPaymentsClient.cancelPayment(PAYMENT_KEY, CANCEL_REASON))
+                        .willThrow(new TossRetryableException(TossErrorCode.PROVIDER_ERROR))
+                        .willThrow(new TossRetryableException(TossErrorCode.PROVIDER_ERROR))
+                        .willReturn(tossCancelResponse);
+
+                // when
+                PaymentCancelResponse response = paymentGatewayAdapter.cancelPayment(PAYMENT_KEY, CANCEL_REASON);
+
+                // then: 성공 응답 반환, 총 3회 호출
+                assertThat(response).isNotNull();
+                assertThat(response.paymentKey()).isEqualTo(PAYMENT_KEY);
+                verify(tossPaymentsClient, times(3)).cancelPayment(PAYMENT_KEY, CANCEL_REASON);
+            }
+
+            @Test
+            @DisplayName("예외 : 재시도 불가능한 예외는 즉시 전파")
+            void cancelPayment_ShouldNotRetryOnNonRetryableException() {
+                // given: RuntimeException은 재시도 대상이 아님
+                given(tossPaymentsClient.cancelPayment(PAYMENT_KEY, CANCEL_REASON))
+                        .willThrow(new RuntimeException("Non-retryable error"));
+
+                // when & then: 예외 발생하며 1회만 호출됨
+                assertThatThrownBy(() ->
+                        paymentGatewayAdapter.cancelPayment(PAYMENT_KEY, CANCEL_REASON)
+                ).isInstanceOf(RuntimeException.class);
+
+                verify(tossPaymentsClient, times(1)).cancelPayment(PAYMENT_KEY, CANCEL_REASON);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("inquirePaymentByOrderId 메서드")
+    class InquirePaymentByOrderIdTest {
+
+        @Nested
+        @DisplayName("재시도 동작")
+        class RetryBehaviorTest {
+
+            @Test
+            @DisplayName("정상 : TossRetryableException 발생 시 최대 3회 재시도")
+            void inquire_ShouldRetryOnTossRetryableException() {
+                // given: 모든 호출에서 TossRetryableException 발생
+                given(tossPaymentsClient.inquirePaymentByOrderId(ORDER_ID))
+                        .willThrow(new TossRetryableException(TossErrorCode.SERVICE_UNAVAILABLE));
+
+                // when & then: 예외 발생하며 3회 호출됨
+                assertThatThrownBy(() ->
+                        paymentGatewayAdapter.inquirePaymentByOrderId(ORDER_ID)
+                ).isInstanceOf(TossRetryableException.class);
+
+                verify(tossPaymentsClient, times(3)).inquirePaymentByOrderId(ORDER_ID);
+            }
+
+            @Test
+            @DisplayName("정상 : 2회 실패 후 3회차에 성공")
+            void inquire_ShouldSucceedOnThirdAttempt() {
+                // given: 2번 실패 후 3번째 성공
+                TossPaymentInquiryResponse successResponse = new TossPaymentInquiryResponse(
+                        "pk_test", ORDER_ID, "DONE", "카드", AMOUNT, OffsetDateTime.now()
+                );
+
+                given(tossPaymentsClient.inquirePaymentByOrderId(ORDER_ID))
+                        .willThrow(new TossRetryableException(TossErrorCode.PROVIDER_ERROR))
+                        .willThrow(new TossRetryableException(TossErrorCode.PROVIDER_ERROR))
+                        .willReturn(successResponse);
+
+                // when
+                TossPaymentInquiryResponse response = paymentGatewayAdapter.inquirePaymentByOrderId(ORDER_ID);
+
+                // then
+                assertThat(response).isEqualTo(successResponse);
+                verify(tossPaymentsClient, times(3)).inquirePaymentByOrderId(ORDER_ID);
+            }
+
+            @Test
+            @DisplayName("예외 : 재시도 불가능한 예외는 즉시 전파")
+            void inquire_ShouldNotRetryOnNonRetryableException() {
+                // given: RuntimeException은 재시도 대상이 아님
+                given(tossPaymentsClient.inquirePaymentByOrderId(ORDER_ID))
+                        .willThrow(new RuntimeException("Non-retryable error"));
+
+                // when & then: 예외 발생하며 1회만 호출됨
+                assertThatThrownBy(() ->
+                        paymentGatewayAdapter.inquirePaymentByOrderId(ORDER_ID)
+                ).isInstanceOf(RuntimeException.class);
+
+                verify(tossPaymentsClient, times(1)).inquirePaymentByOrderId(ORDER_ID);
+            }
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/infra/TossPaymentsErrorHandlerTest.java
+++ b/src/test/java/com/ureca/snac/infra/TossPaymentsErrorHandlerTest.java
@@ -1,0 +1,208 @@
+package com.ureca.snac.infra;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ureca.snac.common.exception.ExternalApiException;
+import com.ureca.snac.infra.dto.response.TossErrorResponse;
+import com.ureca.snac.payment.exception.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("TossPaymentsErrorHandler 단위 테스트")
+class TossPaymentsErrorHandlerTest {
+
+    private TossPaymentsErrorHandler errorHandler;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        errorHandler = new TossPaymentsErrorHandler();
+    }
+
+    @Nested
+    @DisplayName("hasError 메서드")
+    class HasErrorTest {
+
+        @Test
+        @DisplayName("성공 : 4xx 응답 -> true")
+        void hasError_4xxResponse_ReturnsTrue() throws IOException {
+            ClientHttpResponse response = mockResponse(HttpStatus.BAD_REQUEST);
+            assertThat(errorHandler.hasError(response)).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 : 5xx 응답 -> true")
+        void hasError_5xxResponse_ReturnsTrue() throws IOException {
+            ClientHttpResponse response = mockResponse(HttpStatus.INTERNAL_SERVER_ERROR);
+            assertThat(errorHandler.hasError(response)).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 : 2xx 응답 -> false")
+        void hasError_2xxResponse_ReturnsFalse() throws IOException {
+            ClientHttpResponse response = mockResponse(HttpStatus.OK);
+            assertThat(errorHandler.hasError(response)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("handleError 메서드")
+    class HandleErrorTest {
+
+        private static final URI TEST_URI = URI.create("https://api.tosspayments.com/v1/payments/confirm");
+
+        @Test
+        @DisplayName("성공 : retryable 에러코드 -> TossRetryableException")
+        void handleError_RetryableCode_ThrowsTossRetryableException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    new TossErrorResponse("SERVICE_UNAVAILABLE", "서비스 일시 불가", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(TossRetryableException.class);
+        }
+
+        @Test
+        @DisplayName("성공 : INVALID_CARD_NUMBER -> TossInvalidCardInfoException")
+        void handleError_InvalidCardNumber_ThrowsTossInvalidCardInfoException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.BAD_REQUEST,
+                    new TossErrorResponse("INVALID_CARD_NUMBER", "유효하지 않은 카드번호", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(TossInvalidCardInfoException.class);
+        }
+
+        @Test
+        @DisplayName("성공 : REJECT_CARD_COMPANY -> TossInvalidCardInfoException")
+        void handleError_RejectCardCompany_ThrowsTossInvalidCardInfoException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.BAD_REQUEST,
+                    new TossErrorResponse("REJECT_CARD_COMPANY", "카드사 거절", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(TossInvalidCardInfoException.class);
+        }
+
+        @Test
+        @DisplayName("성공 : NOT_ENOUGH_BALANCE -> TossNotEnoughBalanceException")
+        void handleError_NotEnoughBalance_ThrowsTossNotEnoughBalanceException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.BAD_REQUEST,
+                    new TossErrorResponse("NOT_ENOUGH_BALANCE", "잔액 부족", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(TossNotEnoughBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("성공 : EXCEED_MAX_PAYMENT_AMOUNT -> TossNotEnoughBalanceException")
+        void handleError_ExceedMaxPayment_ThrowsTossNotEnoughBalanceException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.BAD_REQUEST,
+                    new TossErrorResponse("EXCEED_MAX_PAYMENT_AMOUNT", "최대 결제 금액 초과", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(TossNotEnoughBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("성공 : INVALID_API_KEY -> TossInvalidApiKeyException")
+        void handleError_InvalidApiKey_ThrowsTossInvalidApiKeyException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.UNAUTHORIZED,
+                    new TossErrorResponse("INVALID_API_KEY", "잘못된 API 키", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(TossInvalidApiKeyException.class);
+        }
+
+        @Test
+        @DisplayName("성공 : UNAUTHORIZED_KEY -> TossInvalidApiKeyException")
+        void handleError_UnauthorizedKey_ThrowsTossInvalidApiKeyException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.UNAUTHORIZED,
+                    new TossErrorResponse("UNAUTHORIZED_KEY", "인증되지 않은 키", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(TossInvalidApiKeyException.class);
+        }
+
+        @Test
+        @DisplayName("성공 : ALREADY_PROCESSED_PAYMENT -> PaymentAlreadyProcessedPaymentException")
+        void handleError_AlreadyProcessed_ThrowsPaymentAlreadyProcessedException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.CONFLICT,
+                    new TossErrorResponse("ALREADY_PROCESSED_PAYMENT", "이미 처리된 결제", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(PaymentAlreadyProcessedPaymentException.class);
+        }
+
+        @Test
+        @DisplayName("성공 : 알 수 없는 non-retryable 코드 -> ExternalApiException")
+        void handleError_UnknownNonRetryableCode_ThrowsExternalApiException() throws Exception {
+            ClientHttpResponse response = mockResponseWithBody(
+                    HttpStatus.BAD_REQUEST,
+                    new TossErrorResponse("FORBIDDEN_REQUEST", "금지된 요청", null)
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(ExternalApiException.class);
+        }
+
+        @Test
+        @DisplayName("실패 : JSON 파싱 실패 -> TossPaymentsAPiCallException")
+        void handleError_JsonParseFailure_ThrowsTossPaymentsApiCallException() throws Exception {
+            ClientHttpResponse response = mockResponseWithRawBody(
+                    HttpStatus.BAD_REQUEST,
+                    "this is not valid json"
+            );
+
+            assertThatThrownBy(() -> errorHandler.handleError(TEST_URI, HttpMethod.POST, response))
+                    .isInstanceOf(TossPaymentsAPiCallException.class);
+        }
+    }
+
+    private ClientHttpResponse mockResponse(HttpStatus status) throws IOException {
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        given(response.getStatusCode()).willReturn(status);
+        return response;
+    }
+
+    private ClientHttpResponse mockResponseWithBody(HttpStatus status, TossErrorResponse errorResponse)
+            throws Exception {
+        String json = objectMapper.writeValueAsString(errorResponse);
+        return mockResponseWithRawBody(status, json);
+    }
+
+    private ClientHttpResponse mockResponseWithRawBody(HttpStatus status, String body) throws IOException {
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        given(response.getStatusCode()).willReturn(status);
+        given(response.getBody())
+                .willReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        return response;
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop  # 스키마 재생성
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: false
@@ -152,6 +152,25 @@ rabbitmq:
       initial-interval: 1000
       multiplier: 2.0
       max-interval: 10000
+
+reconciliation:
+  scheduler:
+    cron: "0 */5 * * * ?"
+    stale-threshold-minutes: 10
+    batch-size: 50
+
+retry:
+  toss:
+    max-attempts: 3
+    delay: 1000
+    multiplier: 2.0
+  depositor:
+    max-attempts: 3
+    delay: 500
+    multiplier: 2.0
+  slack:
+    max-attempts: 3
+    delay: 1000
 
 logging:
   level:


### PR DESCRIPTION
## 변경 사항 요약

@Retryable 기반 재시도 인프라 및 Toss 결제 조회 API 추가

Closes #21

---

## 주요 변경 사항

- RetryProperties 외부 설정 기반 재시도 속성
- TossPaymentsAdapter @Retryable 및 결제 조회 API
- MoneyDepositor @Retryable 추가
- SlackNotifier retry 설정 외부화

> Stacked PR 3/4 — base: `feat/payment-alert-autocancel`