### PR TITLE
[feat] 결제 대사 스케줄러

### DIFF
--- a/src/main/java/com/ureca/snac/config/AggregateExchangeMapper.java
+++ b/src/main/java/com/ureca/snac/config/AggregateExchangeMapper.java
@@ -7,14 +7,15 @@ import java.util.Map;
 /**
  * 도메인과 인프라분리
  * AggregateType은 도메인 레벨
- * Exchange 매핑은 인프라 계층(Config)에서 관리
- * AsyncOutboxPublisher에서 Exchange 결정 시 사용
+ * Exchange 매핑은 인프라 계층
+ * Exchange 결정 시 사용
  */
 public class AggregateExchangeMapper {
 
     private static final Map<AggregateType, String> EXCHANGE_MAP = Map.of(
             AggregateType.MEMBER, RabbitMQQueue.MEMBER_EXCHANGE,
-            AggregateType.WALLET, RabbitMQQueue.WALLET_EXCHANGE
+            AggregateType.WALLET, RabbitMQQueue.WALLET_EXCHANGE,
+            AggregateType.PAYMENT, RabbitMQQueue.PAYMENT_EXCHANGE
     );
 
     public static String getExchange(AggregateType aggregateType) {

--- a/src/main/java/com/ureca/snac/config/OutboxRabbitMQConfig.java
+++ b/src/main/java/com/ureca/snac/config/OutboxRabbitMQConfig.java
@@ -36,7 +36,7 @@ public class OutboxRabbitMQConfig {
     // DLQ 메시지 TTL 설정된 시간이 지나면 자동 삭제되어 무한 증가 방지
     private final int dlqTtlMs;
 
-    public OutboxRabbitMQConfig(@Value("${rabbitmq.dlq.ttl-ms:604800000}") int dlqTtlMs) {
+    public OutboxRabbitMQConfig(@Value("${rabbitmq.dlq.ttl-ms}") int dlqTtlMs) {
         this.dlqTtlMs = dlqTtlMs;
     }
 

--- a/src/main/java/com/ureca/snac/outbox/scheduler/DlqMonitor.java
+++ b/src/main/java/com/ureca/snac/outbox/scheduler/DlqMonitor.java
@@ -42,6 +42,7 @@ public class DlqMonitor {
         try {
             checkAndAlert(RabbitMQQueue.MEMBER_JOINED_DLQ, "회원가입");
             checkAndAlert(RabbitMQQueue.WALLET_CREATED_DLQ, "지갑생성");
+            checkAndAlert(RabbitMQQueue.PAYMENT_CANCEL_COMPENSATE_DLQ, "결제취소보상");
 
         } catch (Exception e) {
             log.error("[DLQ 모니터링] 실패", e);

--- a/src/main/java/com/ureca/snac/outbox/scheduler/OutboxCleanupScheduler.java
+++ b/src/main/java/com/ureca/snac/outbox/scheduler/OutboxCleanupScheduler.java
@@ -25,8 +25,8 @@ public class OutboxCleanupScheduler {
 
     public OutboxCleanupScheduler(
             OutboxRepository outboxRepository,
-            @Value("${outbox.cleanup.retention-days:30}") int retentionDays,
-            @Value("${outbox.cleanup.batch-size:1000}") int batchSize
+            @Value("${outbox.cleanup.retention-days}") int retentionDays,
+            @Value("${outbox.cleanup.batch-size}") int batchSize
     ) {
         this.outboxRepository = outboxRepository;
         this.retentionDays = retentionDays;

--- a/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationProcessor.java
+++ b/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationProcessor.java
@@ -1,0 +1,41 @@
+package com.ureca.snac.payment.scheduler;
+
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.PaymentNotFoundException;
+import com.ureca.snac.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// 대사 스케줄러의 트랜잭션 처리 헬퍼
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentReconciliationProcessor {
+
+    private final PaymentRepository paymentRepository;
+
+    /**
+     * 결제를 취소 상태로 변경 (멱등성 보장)
+     *
+     * @param paymentId    결제 ID
+     * @param cancelReason 취소 사유
+     * @return true: 취소 처리됨, false: 이미 처리된 건 (no-op)
+     */
+    @Transactional
+    public boolean cancelPayment(Long paymentId, String cancelReason) {
+        Payment payment = paymentRepository.findByIdForUpdate(paymentId)
+                .orElseThrow(PaymentNotFoundException::new);
+
+        if (payment.getStatus() != PaymentStatus.PENDING) {
+            log.info("[대사] 이미 처리된 결제 건 스킵. paymentId: {}, status: {}", paymentId, payment.getStatus());
+            return false;
+        }
+
+        payment.cancel(cancelReason);
+        log.info("[대사] 결제 로컬 취소 완료. paymentId: {}, reason: {}", paymentId, cancelReason);
+        return true;
+    }
+}

--- a/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationScheduler.java
+++ b/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationScheduler.java
@@ -1,0 +1,132 @@
+package com.ureca.snac.payment.scheduler;
+
+import com.ureca.snac.common.exception.ExternalApiException;
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.TossRetryableException;
+import com.ureca.snac.payment.repository.PaymentRepository;
+import com.ureca.snac.payment.service.PaymentAlertService;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 결제 대사 스케줄러
+ * <p>
+ * JVM 크래시 등으로 토스에서는 승인됐지만 로컬 DB에 반영되지 않은
+ * PENDING 결제를 감지하고 자동 취소 처리
+ * <p>
+ * 안전 전략: 사용자에게 실패 응답이 갔으므로 승인 완료 대신 자동 환불 처리
+ */
+@Slf4j
+@Component
+public class PaymentReconciliationScheduler {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentGatewayAdapter paymentGatewayAdapter;
+    private final PaymentReconciliationProcessor processor;
+    private final PaymentAlertService paymentAlertService;
+    private final int staleThresholdMinutes;
+    private final int batchSize;
+
+    public PaymentReconciliationScheduler(
+            PaymentRepository paymentRepository,
+            PaymentGatewayAdapter paymentGatewayAdapter,
+            PaymentReconciliationProcessor processor,
+            PaymentAlertService paymentAlertService,
+            @Value("${reconciliation.scheduler.stale-threshold-minutes}") int staleThresholdMinutes,
+            @Value("${reconciliation.scheduler.batch-size}") int batchSize
+    ) {
+        this.paymentRepository = paymentRepository;
+        this.paymentGatewayAdapter = paymentGatewayAdapter;
+        this.processor = processor;
+        this.paymentAlertService = paymentAlertService;
+        this.staleThresholdMinutes = staleThresholdMinutes;
+        this.batchSize = batchSize;
+    }
+
+    @Scheduled(cron = "${reconciliation.scheduler.cron}")
+    @SchedulerLock(name = "paymentReconciliation", lockAtMostFor = "PT4M", lockAtLeastFor = "PT1M")
+    public void reconcileStalePendingPayments() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(staleThresholdMinutes);
+
+        List<Payment> stalePayments = paymentRepository.findStalePendingPayments(
+                PaymentStatus.PENDING, threshold, PageRequest.of(0, batchSize));
+
+        if (stalePayments.isEmpty()) {
+            log.debug("[대사] 문제된 결제 없음");
+            return;
+        }
+
+        log.info("[대사] 문제된 결제 {} 건 발견. 대사 시작", stalePayments.size());
+
+        for (Payment payment : stalePayments) {
+            try {
+                reconcilePayment(payment);
+            } catch (Exception e) {
+                log.error("[대사] 결제 대사 처리 중 예외. paymentId: {}, error: {}",
+                        payment.getId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    private void reconcilePayment(Payment payment) {
+        String orderId = payment.getOrderId();
+
+        TossPaymentInquiryResponse tossResponse;
+        try {
+            tossResponse = paymentGatewayAdapter.inquirePaymentByOrderId(orderId);
+        } catch (TossRetryableException e) {
+            log.warn("[대사] 토스 조회 일시적 오류, 다음 주기에 재시도. orderId: {}", orderId);
+            return;
+        } catch (ExternalApiException e) {
+            // NOT_FOUND_PAYMENT 등 — 토스에 기록 없음, 로컬만 취소
+            log.info("[대사] 토스에 결제 기록 없음. 로컬 취소 진행. orderId: {}", orderId);
+            processor.cancelPayment(payment.getId(), "대사: 토스 결제 기록 없음 (orderId: " + orderId + ")");
+            return;
+        }
+
+        if (tossResponse.isDone()) {
+            handleTossDonePayment(payment, tossResponse);
+        } else if (tossResponse.isCanceledOrFailed()) {
+            log.info("[대사] 토스에서 이미 취소/만료 상태. 로컬 취소 진행. orderId: {}", orderId);
+            processor.cancelPayment(payment.getId(),
+                    "대사: 토스 상태 " + tossResponse.status() + " (orderId: " + orderId + ")");
+        } else {
+            log.info("[대사] 토스 결제 진행 중 상태({}). 스킵. orderId: {}", tossResponse.status(), orderId);
+        }
+    }
+
+    private void handleTossDonePayment(Payment payment, TossPaymentInquiryResponse tossResponse) {
+        String paymentKey = tossResponse.paymentKey();
+        String cancelReason = "대사: JVM 크래시 후 미반영 결제 자동 환불 (orderId: " + payment.getOrderId() + ")";
+
+        try {
+            paymentGatewayAdapter.cancelPayment(paymentKey, cancelReason);
+        } catch (TossRetryableException e) {
+            log.warn("[대사] 토스 취소 일시적 오류, 다음 주기에 재시도. paymentKey: {}", paymentKey);
+            return;
+        } catch (ExternalApiException e) {
+            // ALREADY_CANCELED_PAYMENT 등 — 토스 측 이미 취소됨, 로컬만 취소 진행
+            log.info("[대사] 토스 취소 API 예외 (이미 취소 가능). 로컬 취소 진행. paymentKey: {}, error: {}",
+                    paymentKey, e.getMessage());
+        }
+
+        try {
+            processor.cancelPayment(payment.getId(), cancelReason);
+            paymentAlertService.alertReconciliationAutoCanceled(payment, paymentKey);
+        } catch (Exception e) {
+            log.error("[대사] 로컬 취소 실패! paymentId: {}, error: {}",
+                    payment.getId(), e.getMessage(), e);
+            paymentAlertService.alertReconciliationCancelFailed(payment, paymentKey, e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/integration/PaymentSchedulerIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/PaymentSchedulerIntegrationTest.java
@@ -1,0 +1,237 @@
+package com.ureca.snac.integration;
+
+import com.ureca.snac.common.exception.ExternalApiException;
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.infra.fixture.TossResponseFixture;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
+import com.ureca.snac.money.dto.MoneyRechargeRequest;
+import com.ureca.snac.money.service.MoneyService;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.TossRetryableException;
+import com.ureca.snac.payment.scheduler.PaymentReconciliationScheduler;
+import com.ureca.snac.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+
+import static com.ureca.snac.common.BaseCode.TOSS_API_CALL_ERROR;
+import static com.ureca.snac.infra.TossErrorCode.TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * 결제 대사 스케줄러 통합 테스트
+ * PaymentReconciliationScheduler + PaymentReconciliationProcessor 실제 DB 연동
+ */
+@DisplayName("결제 대사 스케줄러 통합 테스트")
+class PaymentSchedulerIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private PaymentReconciliationScheduler scheduler;
+
+    @Autowired
+    private MoneyService moneyService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private PaymentGatewayAdapter paymentGatewayAdapter;
+
+    private Member member;
+
+    private static final Long RECHARGE_AMOUNT = 10000L;
+
+    @BeforeEach
+    void setUpMember() {
+        member = createMemberWithWallet("sched_");
+    }
+
+    @Nested
+    @DisplayName("대사 스케줄러")
+    class ReconciliationTest {
+
+        @Test
+        @DisplayName("성공 : 미결 결제 없음 -> 동작 없음")
+        void shouldDoNothingWhenNoStalePayments() {
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(paymentGatewayAdapter, never()).inquirePaymentByOrderId(anyString());
+        }
+
+        @Test
+        @DisplayName("성공 : Toss DONE -> 토스 취소 + 로컬 취소 + Payment CANCELED")
+        void shouldCancelTossDonePayment() {
+            // given
+            Payment stalePayment = createStalePendingPayment();
+            String orderId = stalePayment.getOrderId();
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId(orderId))
+                    .willReturn(TossResponseFixture.createInquiryResponse("pk_done", orderId, "DONE"));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(paymentGatewayAdapter).cancelPayment(eq("pk_done"), anyString());
+
+            Payment result = paymentRepository.findById(stalePayment.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        }
+
+        @Test
+        @DisplayName("성공 : Toss CANCELED -> 로컬만 취소")
+        void shouldCancelLocallyForCanceledToss() {
+            // given
+            Payment stalePayment = createStalePendingPayment();
+            String orderId = stalePayment.getOrderId();
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId(orderId))
+                    .willReturn(TossResponseFixture.createInquiryResponse("pk_canceled", orderId, "CANCELED"));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then: Toss cancel 미호출
+            verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+
+            Payment result = paymentRepository.findById(stalePayment.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        }
+
+        @Test
+        @DisplayName("성공 : Toss 기록 없음(ExternalApiException) -> 로컬만 취소")
+        void shouldCancelLocallyWhenTossNotFound() {
+            // given
+            Payment stalePayment = createStalePendingPayment();
+            String orderId = stalePayment.getOrderId();
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId(orderId))
+                    .willThrow(new ExternalApiException(TOSS_API_CALL_ERROR, "NOT_FOUND_PAYMENT"));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            Payment result = paymentRepository.findById(stalePayment.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        }
+
+        @Test
+        @DisplayName("스킵 : Toss 조회 TossRetryableException -> PENDING 유지")
+        void shouldSkipOnRetryableInquiry() {
+            // given
+            Payment stalePayment = createStalePendingPayment();
+            String orderId = stalePayment.getOrderId();
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId(orderId))
+                    .willThrow(new TossRetryableException(TIMEOUT));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            Payment result = paymentRepository.findById(stalePayment.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("스킵 : Toss IN_PROGRESS -> PENDING 유지")
+        void shouldSkipInProgressTossPayment() {
+            // given
+            Payment stalePayment = createStalePendingPayment();
+            String orderId = stalePayment.getOrderId();
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId(orderId))
+                    .willReturn(TossResponseFixture.createInquiryResponse("pk_progress", orderId, "IN_PROGRESS"));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            Payment result = paymentRepository.findById(stalePayment.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("성공 : Toss DONE + ALREADY_CANCELED -> 로컬 취소 진행")
+        void shouldCancelLocallyWhenTossAlreadyCanceled() {
+            // given
+            Payment stalePayment = createStalePendingPayment();
+            String orderId = stalePayment.getOrderId();
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId(orderId))
+                    .willReturn(TossResponseFixture.createInquiryResponse("pk_already", orderId, "DONE"));
+            doThrow(new ExternalApiException(TOSS_API_CALL_ERROR, "ALREADY_CANCELED_PAYMENT"))
+                    .when(paymentGatewayAdapter).cancelPayment(eq("pk_already"), anyString());
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            Payment result = paymentRepository.findById(stalePayment.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        }
+
+        @Test
+        @DisplayName("멱등성 : 이미 처리된 결제 -> Processor false 반환")
+        void shouldSkipAlreadyProcessedPayment() {
+            // given: 충전 완료 후 stale로 만들기 (SUCCESS 상태라 Processor가 false 반환)
+            String paymentKey = "pk_idem_" + System.currentTimeMillis();
+            MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
+                    new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
+            mockTossConfirm(paymentKey);
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
+
+            // Payment를 다시 PENDING으로 변경해서 스케줄러가 잡게 만들지 않음
+            // 대신 createdAt을 과거로 -> 하지만 이미 SUCCESS라 Processor가 false 반환 확인
+            Payment payment = paymentRepository.findByOrderId(prepared.orderId()).orElseThrow();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+
+            // stale로 만들어도 findStalePendingPayments는 PENDING 상태만 조회하므로 잡히지 않음
+            // -> 결국 inquire 미호출
+            scheduler.reconcileStalePendingPayments();
+
+            verify(paymentGatewayAdapter, never()).inquirePaymentByOrderId(anyString());
+        }
+    }
+
+    // ================= Helper ====================
+
+    private Payment createStalePendingPayment() {
+        MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
+                new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
+
+        Payment payment = paymentRepository.findByOrderId(prepared.orderId()).orElseThrow();
+
+        // createdAt을 과거로 설정 (stale threshold: 10분)
+        setStaleCreatedAt(payment.getId());
+
+        return paymentRepository.findById(payment.getId()).orElseThrow();
+    }
+
+    private void setStaleCreatedAt(Long paymentId) {
+        LocalDateTime pastTime = LocalDateTime.now().minusMinutes(30);
+        jdbcTemplate.update(
+                "UPDATE payment SET created_at = ? WHERE payment_id = ?",
+                pastTime, paymentId);
+    }
+
+    private void mockTossConfirm(String paymentKey) {
+        given(paymentGatewayAdapter.confirmPayment(anyString(), anyString(), anyLong()))
+                .willReturn(TossResponseFixture.createConfirmResponse(paymentKey));
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/scheduler/PaymentReconciliationProcessorTest.java
+++ b/src/test/java/com/ureca/snac/payment/scheduler/PaymentReconciliationProcessorTest.java
@@ -1,0 +1,111 @@
+package com.ureca.snac.payment.scheduler;
+
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.PaymentNotFoundException;
+import com.ureca.snac.payment.repository.PaymentRepository;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.PaymentFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentReconciliationProcessor 단위 테스트")
+class PaymentReconciliationProcessorTest {
+
+    @InjectMocks
+    private PaymentReconciliationProcessor processor;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    private final Member member = MemberFixture.createMember(1L);
+
+    @Nested
+    @DisplayName("cancelPayment 메서드")
+    class CancelPaymentTest {
+
+        @Test
+        @DisplayName("PENDING 상태 결제 -> 취소 성공, true 반환")
+        void shouldCancelPendingPayment() {
+            // given
+            Payment payment = PaymentFixture.builder()
+                    .id(1L)
+                    .member(member)
+                    .status(PaymentStatus.PENDING)
+                    .build();
+
+            given(paymentRepository.findByIdForUpdate(1L)).willReturn(Optional.of(payment));
+
+            // when
+            boolean result = processor.cancelPayment(1L, "대사: 자동 취소");
+
+            // then
+            assertThat(result).isTrue();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        }
+
+        @Test
+        @DisplayName("이미 SUCCESS 상태 결제 -> no-op, false 반환")
+        void shouldReturnFalseForSuccessPayment() {
+            // given
+            Payment payment = PaymentFixture.builder()
+                    .id(2L)
+                    .member(member)
+                    .status(PaymentStatus.SUCCESS)
+                    .build();
+
+            given(paymentRepository.findByIdForUpdate(2L)).willReturn(Optional.of(payment));
+
+            // when
+            boolean result = processor.cancelPayment(2L, "대사: 자동 취소");
+
+            // then
+            assertThat(result).isFalse();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 Payment -> PaymentNotFoundException")
+        void shouldThrowWhenPaymentNotFound() {
+            // given
+            given(paymentRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() -> processor.cancelPayment(999L, "대사: 자동 취소"))
+                    .isInstanceOf(PaymentNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("이미 CANCELED 상태 결제 -> no-op, false 반환")
+        void shouldReturnFalseForCanceledPayment() {
+            // given
+            Payment payment = PaymentFixture.builder()
+                    .id(3L)
+                    .member(member)
+                    .status(PaymentStatus.CANCELED)
+                    .build();
+
+            given(paymentRepository.findByIdForUpdate(3L)).willReturn(Optional.of(payment));
+
+            // when
+            boolean result = processor.cancelPayment(3L, "대사: 자동 취소");
+
+            // then
+            assertThat(result).isFalse();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/scheduler/PaymentReconciliationSchedulerTest.java
+++ b/src/test/java/com/ureca/snac/payment/scheduler/PaymentReconciliationSchedulerTest.java
@@ -1,0 +1,285 @@
+package com.ureca.snac.payment.scheduler;
+
+import com.ureca.snac.common.exception.ExternalApiException;
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.infra.TossErrorCode;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.TossRetryableException;
+import com.ureca.snac.payment.repository.PaymentRepository;
+import com.ureca.snac.payment.service.PaymentAlertService;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.PaymentFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static com.ureca.snac.common.BaseCode.TOSS_API_CALL_ERROR;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentReconciliationScheduler 단위 테스트")
+class PaymentReconciliationSchedulerTest {
+
+    private PaymentReconciliationScheduler scheduler;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentGatewayAdapter paymentGatewayAdapter;
+
+    @Mock
+    private PaymentReconciliationProcessor processor;
+
+    @Mock
+    private PaymentAlertService paymentAlertService;
+
+    private final Member member = MemberFixture.createMember(1L);
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new PaymentReconciliationScheduler(
+                paymentRepository,
+                paymentGatewayAdapter,
+                processor,
+                paymentAlertService,
+                10,  // staleThresholdMinutes
+                50   // batchSize
+        );
+    }
+
+    @Nested
+    @DisplayName("reconcileStalePendingPayments 메서드")
+    class ReconcileStalePendingPaymentsTest {
+
+        @Test
+        @DisplayName("미결 결제 없음 -> 조기 종료")
+        void shouldEarlyExitWhenNoStalePayments() {
+            // given
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), eq(PageRequest.of(0, 50))))
+                    .willReturn(List.of());
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verifyNoInteractions(paymentGatewayAdapter, processor, paymentAlertService);
+        }
+
+        @Test
+        @DisplayName("토스 DONE 상태 -> 토스 취소 + 로컬 취소 + 알림")
+        void shouldCancelDonePaymentOnToss() {
+            // given
+            Payment payment = createStalePendingPayment(1L, "order_1");
+
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_done_1", "order_1", "DONE", "카드", 10000L, OffsetDateTime.now());
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_1"))
+                    .willReturn(tossResponse);
+            given(processor.cancelPayment(eq(1L), anyString())).willReturn(true);
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(paymentGatewayAdapter).cancelPayment(eq("pk_done_1"), anyString());
+            verify(processor).cancelPayment(eq(1L), anyString());
+            verify(paymentAlertService).alertReconciliationAutoCanceled(payment, "pk_done_1");
+        }
+
+        @Test
+        @DisplayName("토스 DONE -> 토스 취소 성공 -> 로컬 취소 실패 -> critical 알림")
+        void shouldAlertCriticalWhenLocalCancelFails() {
+            // given
+            Payment payment = createStalePendingPayment(2L, "order_2");
+
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_done_2", "order_2", "DONE", "카드", 10000L, OffsetDateTime.now());
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_2"))
+                    .willReturn(tossResponse);
+            given(processor.cancelPayment(eq(2L), anyString()))
+                    .willThrow(new RuntimeException("DB connection lost"));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(paymentGatewayAdapter).cancelPayment(eq("pk_done_2"), anyString());
+            verify(paymentAlertService).alertReconciliationCancelFailed(
+                    eq(payment), eq("pk_done_2"), eq("DB connection lost"));
+        }
+
+        @Test
+        @DisplayName("토스 CANCELED/ABORTED 상태 -> 로컬만 취소")
+        void shouldCancelLocallyForCanceledTossPayment() {
+            // given
+            Payment payment = createStalePendingPayment(3L, "order_3");
+
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_3", "order_3", "CANCELED", "카드", 10000L, null);
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_3"))
+                    .willReturn(tossResponse);
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(processor).cancelPayment(eq(3L), contains("CANCELED"));
+            verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("토스 조회 일시적 오류(TossRetryableException) -> 스킵")
+        void shouldSkipOnRetryableException() {
+            // given
+            Payment payment = createStalePendingPayment(4L, "order_4");
+
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), any()))
+                    .willReturn(List.of(payment));
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_4"))
+                    .willThrow(new TossRetryableException(TossErrorCode.TIMEOUT));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verifyNoInteractions(processor, paymentAlertService);
+        }
+
+        @Test
+        @DisplayName("토스 조회 NOT_FOUND -> 로컬만 취소")
+        void shouldCancelLocallyWhenTossNotFound() {
+            // given
+            Payment payment = createStalePendingPayment(5L, "order_5");
+
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), any()))
+                    .willReturn(List.of(payment));
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_5"))
+                    .willThrow(new ExternalApiException(TOSS_API_CALL_ERROR, "NOT_FOUND_PAYMENT"));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(processor).cancelPayment(eq(5L), contains("토스 결제 기록 없음"));
+            verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("토스 DONE -> 토스 취소 시 ALREADY_CANCELED 예외 -> 로컬 취소 진행")
+        void shouldCancelLocallyWhenTossAlreadyCanceled() {
+            // given
+            Payment payment = createStalePendingPayment(6L, "order_6");
+
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_done_6", "order_6", "DONE", "카드", 10000L, OffsetDateTime.now());
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_6"))
+                    .willReturn(tossResponse);
+            doThrow(new ExternalApiException(TOSS_API_CALL_ERROR, "ALREADY_CANCELED_PAYMENT"))
+                    .when(paymentGatewayAdapter).cancelPayment(eq("pk_done_6"), anyString());
+            given(processor.cancelPayment(eq(6L), anyString())).willReturn(true);
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(processor).cancelPayment(eq(6L), anyString());
+            verify(paymentAlertService).alertReconciliationAutoCanceled(payment, "pk_done_6");
+        }
+
+        @Test
+        @DisplayName("토스 DONE -> 토스 취소 TossRetryableException -> PENDING 유지 (스킵)")
+        void shouldSkipWhenTossCancelRetryable() {
+            // given
+            Payment payment = createStalePendingPayment(8L, "order_8");
+
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_done_8", "order_8", "DONE", "카드", 10000L, OffsetDateTime.now());
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_8"))
+                    .willReturn(tossResponse);
+            doThrow(new TossRetryableException(TossErrorCode.TIMEOUT))
+                    .when(paymentGatewayAdapter).cancelPayment(eq("pk_done_8"), anyString());
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verifyNoInteractions(processor, paymentAlertService);
+        }
+
+        @Test
+        @DisplayName("토스 진행 중 상태(WAITING_FOR_DEPOSIT) -> 스킵")
+        void shouldSkipInProgressTossPayment() {
+            // given
+            Payment payment = createStalePendingPayment(7L, "order_7");
+
+            given(paymentRepository.findStalePendingPayments(
+                    eq(PaymentStatus.PENDING), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_7", "order_7", "WAITING_FOR_DEPOSIT", "가상계좌", 10000L, null);
+
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_7"))
+                    .willReturn(tossResponse);
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verifyNoInteractions(processor, paymentAlertService);
+        }
+    }
+
+    private Payment createStalePendingPayment(Long id, String orderId) {
+        return PaymentFixture.builder()
+                .id(id)
+                .member(member)
+                .orderId(orderId)
+                .status(PaymentStatus.PENDING)
+                .build();
+    }
+}


### PR DESCRIPTION
## 변경 사항 요약

Stale PENDING 결제 탐지 및 자동 취소 스케줄러

Closes #23

---

## 주요 변경 사항

- PaymentReconciliationScheduler/Processor - stale 결제 탐지 및 Toss 조회 후 자동 처리
- PaymentRepository - findStalePendingPayments 쿼리
- DlqMonitor - payment DLQ 모니터링

> Stacked PR 4/4 — base: `feat/retry-infra-toss-inquiry`