### PR TITLE
[feat] Prometheus + Grafana 모니터링 인프라 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/docker-compose-monitoring.yml
+++ b/docker-compose-monitoring.yml
@@ -1,0 +1,31 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: snac-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=7d'
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: snac-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/grafana/dashboards/snac-payment.json
+++ b/monitoring/grafana/dashboards/snac-payment.json
@@ -1,0 +1,253 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "snac-payment",
+    "title": "SNAC Payment & Outbox Monitoring",
+    "timezone": "Asia/Seoul",
+    "refresh": "5s",
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "panels": [
+      {
+        "id": 1,
+        "title": "Payment Approval Rate (Success / Fail)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "expr": "rate(payment_approval_total{status=\"success\"}[1m])",
+            "legendFormat": "Success"
+          },
+          {
+            "expr": "rate(payment_approval_total{status=\"fail\"}[1m])",
+            "legendFormat": "Fail"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops"
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "Payment Approval Duration (p95)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, rate(payment_approval_duration_seconds_bucket[1m]))",
+            "legendFormat": "p95"
+          },
+          {
+            "expr": "histogram_quantile(0.99, rate(payment_approval_duration_seconds_bucket[1m]))",
+            "legendFormat": "p99"
+          },
+          {
+            "expr": "rate(payment_approval_duration_seconds_sum[1m]) / rate(payment_approval_duration_seconds_count[1m])",
+            "legendFormat": "avg"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s"
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Outbox Events Published (Success / Fail)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+        "targets": [
+          {
+            "expr": "rate(outbox_events_published_total{result=\"success\"}[1m])",
+            "legendFormat": "Published"
+          },
+          {
+            "expr": "rate(outbox_events_published_total{result=\"fail\"}[1m])",
+            "legendFormat": "Failed"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops"
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Outbox Polling Recovery",
+        "type": "stat",
+        "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+        "targets": [
+          {
+            "expr": "outbox_polling_recovery_total",
+            "legendFormat": "Recovery Count"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": 0 },
+                { "color": "yellow", "value": 1 },
+                { "color": "red", "value": 10 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "Compensation Triggered",
+        "type": "stat",
+        "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+        "targets": [
+          {
+            "expr": "payment_compensation_triggered_total",
+            "legendFormat": "Compensation Count"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": 0 },
+                { "color": "orange", "value": 1 },
+                { "color": "red", "value": 5 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Reconciliation Resolved",
+        "type": "stat",
+        "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+        "targets": [
+          {
+            "expr": "payment_reconciliation_resolved_total",
+            "legendFormat": "Resolved"
+          }
+        ]
+      },
+      {
+        "id": 7,
+        "title": "Idempotency Duplicates Blocked",
+        "type": "stat",
+        "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
+        "targets": [
+          {
+            "expr": "idempotency_duplicate_blocked_total",
+            "legendFormat": "Blocked"
+          }
+        ]
+      },
+      {
+        "id": 8,
+        "title": "DLQ Message Count by Queue",
+        "type": "bargauge",
+        "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+        "targets": [
+          {
+            "expr": "dlq_messages_routed_total",
+            "legendFormat": "{{queue}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": 0 },
+                { "color": "red", "value": 1 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 9,
+        "title": "HikariCP Connection Pool",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+        "targets": [
+          {
+            "expr": "hikaricp_connections_active",
+            "legendFormat": "Active"
+          },
+          {
+            "expr": "hikaricp_connections_idle",
+            "legendFormat": "Idle"
+          },
+          {
+            "expr": "hikaricp_connections_pending",
+            "legendFormat": "Pending"
+          },
+          {
+            "expr": "hikaricp_connections_max",
+            "legendFormat": "Max"
+          }
+        ]
+      },
+      {
+        "id": 10,
+        "title": "JVM Memory & Threads",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+        "targets": [
+          {
+            "expr": "jvm_memory_used_bytes{area=\"heap\"} / 1024 / 1024",
+            "legendFormat": "Heap Used (MB)"
+          },
+          {
+            "expr": "jvm_threads_live_threads",
+            "legendFormat": "Live Threads"
+          }
+        ]
+      },
+      {
+        "id": 11,
+        "title": "HTTP Request Duration (p95)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, rate(http_server_requests_seconds_bucket{uri!~\"/actuator.*\"}[1m]))",
+            "legendFormat": "{{method}} {{uri}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s"
+          }
+        }
+      },
+      {
+        "id": 12,
+        "title": "Toss API Duration (p95)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, rate(toss_api_duration_seconds_bucket[1m]))",
+            "legendFormat": "{{method}} p95"
+          },
+          {
+            "expr": "rate(toss_api_duration_seconds_sum[1m]) / rate(toss_api_duration_seconds_count[1m])",
+            "legendFormat": "{{method}} avg"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s"
+          }
+        }
+      }
+    ]
+  },
+  "overwrite": true
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'snac-backend'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+        labels:
+          application: 'snac-server'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -186,6 +186,18 @@ aes:
   salt: ${AES_SALT}
 
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus,metrics
+  endpoint:
+    health:
+      show-details: when-authorized
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
 logging:
   level:
     com.ureca.snac.auth.config.SecurityConfig: DEBUG


### PR DESCRIPTION
## 변경 사항 요약

Prometheus + Grafana 기반 모니터링 인프라 구성

Closes #25

---

## 주요 변경 사항

### 1. 의존성 및 설정

**build.gradle**

- `micrometer-registry-prometheus` 의존성 추가

**application.yml**

- Actuator 엔드포인트 노출 (health, prometheus, metrics)
- 공통 메트릭 태그 설정 (`application: snac-server`)

### 2. 모니터링 컨테이너

**docker-compose-monitoring.yml**

- Prometheus (port 9090): 5초 간격 scrape
- Grafana (port 3000): 자동 프로비저닝

### 3. Grafana 대시보드

**monitoring/grafana/dashboards/snac-payment.json**

- 비즈니스 메트릭 패널: 결제 승인률, Outbox 발행, 보상 트랜잭션, 대사 처리, 멱등성, DLQ
- 인프라 메트릭 패널: HikariCP 커넥션 풀, JVM 메모리/스레드, HTTP p95, Toss API 응답시간

---

## 동작 흐름

### 실행 방법

```
docker-compose -f docker-compose-monitoring.yml up -d
→ Prometheus: localhost:9090
→ Grafana: localhost:3000 (admin/admin)
→ 대시보드 자동 로드
```

---

## 기술적 의사결정

### 왜 별도 docker-compose 파일인가?

**문제**
- 기존 docker-compose.yml은 MySQL/Redis/RabbitMQ 운영 인프라 전용

**해결**
- 모니터링은 선택적 구성이므로 별도 파일로 분리
- 개발 시: `docker-compose up` (기존)
- 모니터링 필요 시: `docker-compose -f docker-compose-monitoring.yml up -d` (추가)

**비교**
- 단일 파일 통합: 모니터링 불필요 시에도 항상 컨테이너 구동됨