### PR TITLE
[feat] 비즈니스 메트릭 15개 계측

### DIFF
--- a/src/main/java/com/ureca/snac/infra/TossPaymentsAdapter.java
+++ b/src/main/java/com/ureca/snac/infra/TossPaymentsAdapter.java
@@ -6,6 +6,9 @@ import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
 import com.ureca.snac.payment.dto.PaymentCancelResponse;
 import com.ureca.snac.payment.exception.TossRetryableException;
 import com.ureca.snac.payment.mapper.PaymentCancelMapper;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
@@ -30,6 +33,7 @@ public class TossPaymentsAdapter implements PaymentGatewayAdapter {
     private final TossPaymentsClient tossPaymentsClient;
     // DTO 매퍼
     private final PaymentCancelMapper paymentCancelMapper;
+    private final MeterRegistry meterRegistry;
 
     @Retryable(
             retryFor = {TossRetryableException.class},
@@ -39,8 +43,20 @@ public class TossPaymentsAdapter implements PaymentGatewayAdapter {
     )
     @Override
     public TossConfirmResponse confirmPayment(String paymentKey, String orderId, Long amount) {
-        log.debug("[Toss API] confirmPayment 호출. paymentKey: {}, orderId: {}", paymentKey, orderId);
-        return tossPaymentsClient.confirmPayment(paymentKey, orderId, amount);
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String result = "success";
+        try {
+            log.debug("[Toss API] confirmPayment 호출. paymentKey: {}, orderId: {}", paymentKey, orderId);
+            return tossPaymentsClient.confirmPayment(paymentKey, orderId, amount);
+        } catch (Exception e) {
+            result = "fail";
+            throw e;
+        } finally {
+            sample.stop(Timer.builder("toss_api_duration").tag("method", "confirm").register(meterRegistry));
+            Counter.builder("toss_api_call_total")
+                    .tag("method", "confirm").tag("result", result)
+                    .register(meterRegistry).increment();
+        }
     }
 
     @Retryable(
@@ -51,12 +67,24 @@ public class TossPaymentsAdapter implements PaymentGatewayAdapter {
     )
     @Override
     public PaymentCancelResponse cancelPayment(String paymentKey, String reason) {
-        log.debug("[Toss API] cancelPayment 호출. paymentKey: {}", paymentKey);
-        // 외부 통신에게 결제 취소 요청
-        TossCancelResponse tossResponse = tossPaymentsClient.cancelPayment(paymentKey, reason);
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String result = "success";
+        try {
+            log.debug("[Toss API] cancelPayment 호출. paymentKey: {}", paymentKey);
+            // 외부 통신에게 결제 취소 요청
+            TossCancelResponse tossResponse = tossPaymentsClient.cancelPayment(paymentKey, reason);
 
-        // 응답을 매퍼에 전달해서 서비스 DTO로 변경
-        return paymentCancelMapper.toPaymentCancelResponse(tossResponse);
+            // 응답을 매퍼에 전달해서 서비스 DTO로 변경
+            return paymentCancelMapper.toPaymentCancelResponse(tossResponse);
+        } catch (Exception e) {
+            result = "fail";
+            throw e;
+        } finally {
+            sample.stop(Timer.builder("toss_api_duration").tag("method", "cancel").register(meterRegistry));
+            Counter.builder("toss_api_call_total")
+                    .tag("method", "cancel").tag("result", result)
+                    .register(meterRegistry).increment();
+        }
     }
 
     @Retryable(
@@ -67,7 +95,19 @@ public class TossPaymentsAdapter implements PaymentGatewayAdapter {
     )
     @Override
     public TossPaymentInquiryResponse inquirePaymentByOrderId(String orderId) {
-        log.debug("[Toss API] inquirePaymentByOrderId 호출. orderId: {}", orderId);
-        return tossPaymentsClient.inquirePaymentByOrderId(orderId);
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String result = "success";
+        try {
+            log.debug("[Toss API] inquirePaymentByOrderId 호출. orderId: {}", orderId);
+            return tossPaymentsClient.inquirePaymentByOrderId(orderId);
+        } catch (Exception e) {
+            result = "fail";
+            throw e;
+        } finally {
+            sample.stop(Timer.builder("toss_api_duration").tag("method", "inquire").register(meterRegistry));
+            Counter.builder("toss_api_call_total")
+                    .tag("method", "inquire").tag("result", result)
+                    .register(meterRegistry).increment();
+        }
     }
 }

--- a/src/main/java/com/ureca/snac/outbox/listener/OutboxEventListener.java
+++ b/src/main/java/com/ureca/snac/outbox/listener/OutboxEventListener.java
@@ -8,6 +8,8 @@ import com.ureca.snac.outbox.entity.Outbox;
 import com.ureca.snac.outbox.event.OutboxScheduledEvent;
 import com.ureca.snac.outbox.exception.OutboxSerializationException;
 import com.ureca.snac.outbox.repository.OutboxRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,6 +32,7 @@ public class OutboxEventListener {
     private final OutboxRepository outboxRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     /**
      * Hybrid Push 대상 이벤트 화이트리스트
@@ -63,6 +66,9 @@ public class OutboxEventListener {
             );
 
             outboxRepository.save(outbox);
+            Counter.builder("outbox_events_saved_total")
+                    .register(meterRegistry)
+                    .increment();
 
             log.info("[Outbox] 이벤트 저장 완료. outboxId: {}, eventType: {}",
                     outbox.getId(), outbox.getEventType());

--- a/src/main/java/com/ureca/snac/outbox/repository/OutboxRepository.java
+++ b/src/main/java/com/ureca/snac/outbox/repository/OutboxRepository.java
@@ -82,7 +82,7 @@ public interface OutboxRepository extends JpaRepository<Outbox, Long> {
      * INIT 또는 SEND_FAIL 상태 경쟁 상태(Race Condition) 방지
      * <p>
      * AsyncOutboxPublisher: INIT에서 PUBLISHED
-     * OutboxPublisher (스케줄러): SEND_FAIL, INIT에서 PUBLISHED
+     * OutboxPollingScheduler: SEND_FAIL, INIT에서 PUBLISHED
      *
      * @param id  Outbox ID
      * @param now 발행 시각

--- a/src/main/java/com/ureca/snac/outbox/service/OutboxMessagePublisher.java
+++ b/src/main/java/com/ureca/snac/outbox/service/OutboxMessagePublisher.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * 메시지 발행 공통 컴포넌트
- * OutboxPublisher, AsyncOutboxPublisher에서 위임하여 사용
+ * OutboxPollingScheduler, AsyncOutboxPublisher에서 위임하여 사용
  * AggregateType/EventType 변환 + 메시지 발행 + 헤더 설정
  */
 @Slf4j

--- a/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationProcessor.java
+++ b/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationProcessor.java
@@ -4,6 +4,8 @@ import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.entity.PaymentStatus;
 import com.ureca.snac.payment.exception.PaymentNotFoundException;
 import com.ureca.snac.payment.repository.PaymentRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentReconciliationProcessor {
 
     private final PaymentRepository paymentRepository;
+    private final MeterRegistry meterRegistry;
 
     /**
      * 결제를 취소 상태로 변경 (멱등성 보장)
@@ -35,6 +38,9 @@ public class PaymentReconciliationProcessor {
         }
 
         payment.cancel(cancelReason);
+        Counter.builder("payment_reconciliation_resolved_total")
+                .register(meterRegistry)
+                .increment();
         log.info("[대사] 결제 로컬 취소 완료. paymentId: {}, reason: {}", paymentId, cancelReason);
         return true;
     }

--- a/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationScheduler.java
+++ b/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationScheduler.java
@@ -8,6 +8,8 @@ import com.ureca.snac.payment.entity.PaymentStatus;
 import com.ureca.snac.payment.exception.TossRetryableException;
 import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.payment.service.PaymentAlertService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +36,7 @@ public class PaymentReconciliationScheduler {
     private final PaymentGatewayAdapter paymentGatewayAdapter;
     private final PaymentReconciliationProcessor processor;
     private final PaymentAlertService paymentAlertService;
+    private final MeterRegistry meterRegistry;
     private final int staleThresholdMinutes;
     private final int batchSize;
 
@@ -42,6 +45,7 @@ public class PaymentReconciliationScheduler {
             PaymentGatewayAdapter paymentGatewayAdapter,
             PaymentReconciliationProcessor processor,
             PaymentAlertService paymentAlertService,
+            MeterRegistry meterRegistry,
             @Value("${reconciliation.scheduler.stale-threshold-minutes}") int staleThresholdMinutes,
             @Value("${reconciliation.scheduler.batch-size}") int batchSize
     ) {
@@ -49,6 +53,7 @@ public class PaymentReconciliationScheduler {
         this.paymentGatewayAdapter = paymentGatewayAdapter;
         this.processor = processor;
         this.paymentAlertService = paymentAlertService;
+        this.meterRegistry = meterRegistry;
         this.staleThresholdMinutes = staleThresholdMinutes;
         this.batchSize = batchSize;
     }

--- a/src/main/java/com/ureca/snac/wallet/service/WalletServiceImpl.java
+++ b/src/main/java/com/ureca/snac/wallet/service/WalletServiceImpl.java
@@ -8,6 +8,8 @@ import com.ureca.snac.wallet.entity.Wallet;
 import com.ureca.snac.wallet.event.WalletCreatedEvent;
 import com.ureca.snac.wallet.exception.InsufficientBalanceException;
 import com.ureca.snac.wallet.exception.WalletNotFoundException;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -22,6 +24,7 @@ public class WalletServiceImpl implements WalletService {
 
     private final WalletRepository walletRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final MeterRegistry meterRegistry;
 
     @Override
     @Transactional
@@ -67,6 +70,9 @@ public class WalletServiceImpl implements WalletService {
 
         long finalBalance = wallet.getMoneyBalance();
         log.info("[머니 입금] 완료. 회원 ID : {}, 최종 머니 잔액 : {}", memberId, finalBalance);
+        Counter.builder("wallet_operation_total")
+                .tag("type", "deposit_money")
+                .register(meterRegistry).increment();
 
         return finalBalance;
     }
@@ -81,6 +87,9 @@ public class WalletServiceImpl implements WalletService {
 
         long finalBalance = wallet.getMoneyBalance();
         log.info("[머니 출금] 완료. 회원 ID: {}, 최종 잔액: {}", memberId, finalBalance);
+        Counter.builder("wallet_operation_total")
+                .tag("type", "withdraw_money")
+                .register(meterRegistry).increment();
 
         return finalBalance;
     }
@@ -139,6 +148,9 @@ public class WalletServiceImpl implements WalletService {
 
         long finalBalance = wallet.getPointBalance();
         log.info("[포인트 적립] 완료. 회원 ID: {}, 최종 잔액: {}", memberId, finalBalance);
+        Counter.builder("wallet_operation_total")
+                .tag("type", "deposit_point")
+                .register(meterRegistry).increment();
 
         return finalBalance;
 
@@ -154,6 +166,9 @@ public class WalletServiceImpl implements WalletService {
 
         long finalBalance = wallet.getPointBalance();
         log.info("[포인트 사용] 완료. 회원 ID: {}, 최종 잔액: {}", memberId, finalBalance);
+        Counter.builder("wallet_operation_total")
+                .tag("type", "withdraw_point")
+                .register(meterRegistry).increment();
 
         return finalBalance;
     }

--- a/src/test/java/com/ureca/snac/payment/scheduler/PaymentReconciliationSchedulerTest.java
+++ b/src/test/java/com/ureca/snac/payment/scheduler/PaymentReconciliationSchedulerTest.java
@@ -12,6 +12,7 @@ import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.payment.service.PaymentAlertService;
 import com.ureca.snac.support.fixture.MemberFixture;
 import com.ureca.snac.support.fixture.PaymentFixture;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -56,6 +57,7 @@ class PaymentReconciliationSchedulerTest {
                 paymentGatewayAdapter,
                 processor,
                 paymentAlertService,
+                new SimpleMeterRegistry(),
                 10,  // staleThresholdMinutes
                 50   // batchSize
         );


### PR DESCRIPTION
## 변경 사항 요약

Micrometer Counter/Timer/Gauge 기반 비즈니스 메트릭 15개 계측

Closes #27

---

## 주요 변경 사항

### 1. 결제 파이프라인 메트릭 (5개)

**MoneyServiceImpl**
- `payment_approval_total` (Counter, status: success|fail)
- `payment_approval_duration` (Timer)

**PaymentServiceImpl**
- `payment_cancel_total` (Counter, status: success|fail|compensated)

**PaymentInternalService**
- `payment_compensation_triggered_total` (Counter)

### 2. 외부 API 메트릭 (2개)

**TossPaymentsAdapter**
- `toss_api_duration` (Timer, method: confirm|cancel|inquire)
- `toss_api_call_total` (Counter, method, result: success|fail)

### 3. Outbox 이벤트 메트릭 (3개)

**OutboxEventListener**
- `outbox_events_saved_total` (Counter)

**OutboxPollingScheduler, AsyncOutboxPublisher**
- `outbox_events_published_total` (Counter, result: success|fail)
- `outbox_polling_recovery_total` (Counter)

### 4. 리스너 메트릭 (1개 x 3 리스너)

**WalletCreationListener, SignupBonusListener, PaymentCancelCompensationListener**
- `listener_message_processed_total` (Counter, queue, result: success|fail|dlq)

### 5. 정합성 메트릭 (4개)

**AssetRecorderImpl**
- `idempotency_duplicate_blocked_total` (Counter)

**PaymentReconciliationProcessor**
- `payment_reconciliation_resolved_total` (Counter)

**DlqMonitor**
- `dlq_messages_routed_total` (Gauge, queue)

**WalletServiceImpl**
- `wallet_operation_total` (Counter, type: deposit_money|withdraw_money|deposit_point|withdraw_point)

---

## 기술적 의사결정

### 왜 Counter.builder().register().increment() 패턴인가?

**문제**
- 필드에 Counter를 미리 생성하면 태그 조합별로 필드가 증가

**해결**
- Micrometer의 register()는 내부적으로 캐시하여 동일 이름+태그 조합은 같은 인스턴스 반환
- 호출 시점에 태그를 동적으로 지정 가능 (success|fail 분기)