### PR TITLE
[feat] nGrinder 부하 테스트 환경 구성 + Publisher Confirms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ out/
 
 .env
 docker-compose.yml
+
+### nGrinder (부하 테스트 도구) ###
+ngrinder/
+docker-compose-ngrinder.yml

--- a/src/main/java/com/ureca/snac/config/RabbitMQConfig.java
+++ b/src/main/java/com/ureca/snac/config/RabbitMQConfig.java
@@ -380,6 +380,7 @@ public class RabbitMQConfig {
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, Jackson2JsonMessageConverter converter) {
         RabbitTemplate template = new RabbitTemplate(connectionFactory);
         template.setMessageConverter(converter);
+        template.setMandatory(true);  // 라우팅 불가 메시지 반환 감지 (publisher-returns와 연동)
         return template;
     }
 

--- a/src/main/java/com/ureca/snac/config/StompRelayProperties.java
+++ b/src/main/java/com/ureca/snac/config/StompRelayProperties.java
@@ -3,8 +3,10 @@ package com.ureca.snac.config;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+@Profile("!loadtest")
 @Data
 @Component
 @ConfigurationProperties(prefix = "custom.stomp")

--- a/src/main/java/com/ureca/snac/config/WebConfigRabbitMQ.java
+++ b/src/main/java/com/ureca/snac/config/WebConfigRabbitMQ.java
@@ -4,7 +4,6 @@ import com.ureca.snac.auth.util.JWTUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -27,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import static com.ureca.snac.common.RedisKeyConstants.WS_CONNECTED_PREFIX;
 
 @Configuration
-@Profile("!scheduler")
+@Profile("!loadtest")
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebConfigRabbitMQ implements WebSocketMessageBrokerConfigurer {

--- a/src/main/java/com/ureca/snac/infra/TossPaymentsAdapter.java
+++ b/src/main/java/com/ureca/snac/infra/TossPaymentsAdapter.java
@@ -12,6 +12,7 @@ import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Primary
 @Component
+@Profile("!loadtest")
 @RequiredArgsConstructor
 public class TossPaymentsAdapter implements PaymentGatewayAdapter {
 

--- a/src/main/java/com/ureca/snac/loadtest/FaultInjectionAspect.java
+++ b/src/main/java/com/ureca/snac/loadtest/FaultInjectionAspect.java
@@ -1,0 +1,39 @@
+package com.ureca.snac.loadtest;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * 부하 테스트 전용 장애 주입 Aspect
+ * <p>
+ * MoneyDepositor.deposit() 에 확률적 예외를 발생시켜
+ * "Toss 승인 성공 + DB 실패" 시나리오를 유발한다.
+ * <p>
+ * RuntimeException 을 던지므로 @Retryable(retryFor = DataAccessException) 에 해당하지 않아
+ * 재시도 없이 즉시 Auto-Cancel chain 이 발동한다.
+ */
+@Slf4j
+@Aspect
+@Component
+@Profile("loadtest")
+public class FaultInjectionAspect {
+
+    @Value("${loadtest.fault.deposit-failure-rate}")
+    private double depositFailureRate;
+
+    @Around("execution(* com.ureca.snac.money.service.MoneyDepositor.deposit(..))")
+    public Object injectDepositFault(ProceedingJoinPoint joinPoint) throws Throwable {
+        if (ThreadLocalRandom.current().nextDouble() < depositFailureRate) {
+            log.warn("[LoadTest 장애 주입] MoneyDepositor.deposit() 예외 발생");
+            throw new RuntimeException("[LoadTest] Injected deposit failure for compensation test");
+        }
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/ureca/snac/loadtest/LoadTestController.java
+++ b/src/main/java/com/ureca/snac/loadtest/LoadTestController.java
@@ -1,0 +1,42 @@
+package com.ureca.snac.loadtest;
+
+import com.ureca.snac.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.ureca.snac.common.BaseCode.USER_SIGNUP_SUCCESS;
+
+@RestController
+@Profile("loadtest")
+@RequestMapping("/api/loadtest")
+@RequiredArgsConstructor
+public class LoadTestController {
+
+    private final LoadTestService loadTestService;
+
+    @PostMapping("/join")
+    public ResponseEntity<ApiResponse<Void>> joinForLoadTest(@RequestBody LoadTestJoinRequest request) {
+        loadTestService.joinForLoadTest(
+                request.email(),
+                request.password(),
+                request.name(),
+                request.nickname(),
+                request.phone()
+        );
+        return ResponseEntity.ok(ApiResponse.ok(USER_SIGNUP_SUCCESS));
+    }
+
+    public record LoadTestJoinRequest(
+            String email,
+            String password,
+            String name,
+            String nickname,
+            String phone
+    ) {
+    }
+}

--- a/src/main/java/com/ureca/snac/loadtest/LoadTestService.java
+++ b/src/main/java/com/ureca/snac/loadtest/LoadTestService.java
@@ -1,0 +1,58 @@
+package com.ureca.snac.loadtest;
+
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.member.event.MemberJoinEvent;
+import com.ureca.snac.member.exception.EmailDuplicateException;
+import com.ureca.snac.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static com.ureca.snac.member.Activated.NORMAL;
+import static com.ureca.snac.member.Role.USER;
+
+/**
+ * 부하 테스트 전용 회원가입 서비스
+ * 이메일/SMS 인증을 건너뛰고 회원 생성 + MemberJoinEvent 발행
+ */
+@Slf4j
+@Service
+@Profile("loadtest")
+@RequiredArgsConstructor
+public class LoadTestService {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void joinForLoadTest(String email, String password, String name, String nickname, String phone) {
+
+        if (memberRepository.existsByEmail(email)) {
+            throw new EmailDuplicateException();
+        }
+
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .name(name)
+                .nickname(nickname)
+                .phone(phone)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .role(USER)
+                .ratingScore(100)
+                .activated(NORMAL)
+                .build();
+
+        memberRepository.save(member);
+        log.info("[LoadTest 회원가입] 완료. email: {}", email);
+
+        eventPublisher.publishEvent(new MemberJoinEvent(member.getId()));
+    }
+}

--- a/src/main/java/com/ureca/snac/loadtest/MockPaymentGatewayAdapter.java
+++ b/src/main/java/com/ureca/snac/loadtest/MockPaymentGatewayAdapter.java
@@ -1,0 +1,77 @@
+package com.ureca.snac.loadtest;
+
+import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.common.exception.ExternalApiException;
+import com.ureca.snac.infra.PaymentGatewayAdapter;
+import com.ureca.snac.infra.dto.response.TossConfirmResponse;
+import com.ureca.snac.infra.dto.response.TossPaymentInquiryResponse;
+import com.ureca.snac.payment.dto.PaymentCancelResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * 부하 테스트 전용 Toss Mock Adapter
+ * <p>
+ * confirm : 항상 성공, orderId -> paymentKey 매핑 저장
+ * cancel : 대사 스케줄러 케이스 유발을 위한 확률적 실패
+ * inquiry : confirm 된 건은 DONE, 아닌 건은 ExternalApiException
+ */
+@Slf4j
+@Primary
+@Component
+@Profile("loadtest")
+public class MockPaymentGatewayAdapter implements PaymentGatewayAdapter {
+
+    @Value("${loadtest.fault.cancel-failure-rate}")
+    private double cancelFailureRate;
+
+    private final ConcurrentHashMap<String, String> confirmedPayments = new ConcurrentHashMap<>();
+
+    @Override
+    public TossConfirmResponse confirmPayment(String paymentKey, String orderId, Long amount) {
+        log.debug("[Mock Toss] confirmPayment 성공. paymentKey: {}, orderId: {}", paymentKey, orderId);
+        confirmedPayments.put(orderId, paymentKey);
+
+        return new TossConfirmResponse(paymentKey, "카드", OffsetDateTime.now());
+    }
+
+    @Override
+    public PaymentCancelResponse cancelPayment(String paymentKey, String reason) {
+        if (ThreadLocalRandom.current().nextDouble() < cancelFailureRate) {
+            log.warn("[Mock Toss] cancelPayment 장애 주입. paymentKey: {}", paymentKey);
+            throw new ExternalApiException(BaseCode.TOSS_API_CALL_ERROR,
+                    "[LoadTest] Mock cancel failure for reconciliation test");
+        }
+
+        log.debug("[Mock Toss] cancelPayment 성공. paymentKey: {}", paymentKey);
+        return PaymentCancelResponse.builder()
+                .paymentKey(paymentKey)
+                .canceledAmount(0L)
+                .canceledAt(OffsetDateTime.now())
+                .reason(reason)
+                .build();
+    }
+
+    @Override
+    public TossPaymentInquiryResponse inquirePaymentByOrderId(String orderId) {
+        String paymentKey = confirmedPayments.get(orderId);
+
+        if (paymentKey == null) {
+            log.debug("[Mock Toss] inquiry NOT_FOUND. orderId: {}", orderId);
+            throw new ExternalApiException(BaseCode.TOSS_API_CALL_ERROR,
+                    "[Mock] Payment not found: " + orderId);
+        }
+
+        log.debug("[Mock Toss] inquiry DONE. orderId: {}", orderId);
+        return new TossPaymentInquiryResponse(
+                paymentKey, orderId, "DONE", "카드", 0L, OffsetDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/ureca/snac/notification/listener/NotificationListener.java
+++ b/src/main/java/com/ureca/snac/notification/listener/NotificationListener.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@Profile("!scheduler")
+@Profile("!scheduler & !loadtest")
 @RequiredArgsConstructor
 public class NotificationListener {
     private final SimpMessagingTemplate messaging;

--- a/src/main/java/com/ureca/snac/outbox/service/OutboxMessagePublisher.java
+++ b/src/main/java/com/ureca/snac/outbox/service/OutboxMessagePublisher.java
@@ -5,29 +5,43 @@ import com.ureca.snac.common.event.EventType;
 import com.ureca.snac.config.AggregateExchangeMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * 메시지 발행 공통 컴포넌트
  * OutboxPollingScheduler, AsyncOutboxPublisher에서 위임하여 사용
  * AggregateType/EventType 변환 + 메시지 발행 + 헤더 설정
+ * <p>
+ * Publisher Confirms:
+ * rabbitTemplate.convertAndSend() 후 브로커의 ACK/NACK을 대기하여
+ * 메시지가 실제로 브로커에 도달했는지 확인한다.
+ * 확인 실패 시 예외를 던져 호출자가 SEND_FAIL로 처리하도록 한다.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OutboxMessagePublisher {
 
+    private static final long CONFIRM_TIMEOUT_SECONDS = 5;
+
     private final RabbitTemplate rabbitTemplate;
 
     /**
-     * RabbitMQ로 메시지 발행
+     * RabbitMQ로 메시지 발행 + 브로커 수신 확인 (Publisher Confirms)
      *
      * @param eventId           이벤트 고유 식별자 (Consumer 측 멱등성 검증용)
      * @param aggregateTypeName Aggregate 타입명
      * @param eventTypeName     이벤트 타입명
      * @param aggregateId       Aggregate ID
      * @param payload           JSON 페이로드
+     * @throws AmqpException 브로커 NACK, 타임아웃, 연결 실패 시
      */
     public void publish(
             String eventId,
@@ -40,6 +54,8 @@ public class OutboxMessagePublisher {
         EventType eventType = EventType.from(eventTypeName);
         String exchange = AggregateExchangeMapper.getExchange(aggregateType);
 
+        CorrelationData correlationData = new CorrelationData(eventId);
+
         rabbitTemplate.convertAndSend(
                 exchange,
                 eventType.getRoutingKey(),
@@ -49,10 +65,34 @@ public class OutboxMessagePublisher {
                     message.getMessageProperties().setHeader("eventType", eventTypeName);
                     message.getMessageProperties().setHeader("aggregateId", aggregateId);
                     return message;
-                }
+                },
+                correlationData
         );
 
-        log.debug("[OutboxMessagePublisher] 발행 완료. exchange: {}, routingKey: {}, eventId: {}, aggregateId: {}",
+        // 브로커 수신 확인 대기 (Publisher Confirms)
+        waitForConfirm(correlationData, eventId);
+
+        log.debug("[OutboxMessagePublisher] 발행 + 브로커 확인 완료. exchange: {}, routingKey: {}, eventId: {}, aggregateId: {}",
                 exchange, eventType.getRoutingKey(), eventId, aggregateId);
+    }
+
+    // CorrelationData 기반으로 브로커 확인 대기 (5초 타임아웃)
+    private void waitForConfirm(CorrelationData correlationData, String eventId) {
+        try {
+            CorrelationData.Confirm confirm = correlationData.getFuture()
+                    .get(CONFIRM_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            if (!confirm.isAck()) {
+                throw new AmqpException(
+                        "브로커 NACK. eventId: " + eventId + ", reason: " + confirm.getReason());
+            }
+        } catch (TimeoutException e) {
+            throw new AmqpException("Publisher Confirm 타임아웃 (" + CONFIRM_TIMEOUT_SECONDS + "s). eventId: " + eventId, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AmqpException("Publisher Confirm 인터럽트. eventId: " + eventId, e);
+        } catch (ExecutionException e) {
+            throw new AmqpException("Publisher Confirm 실행 오류. eventId: " + eventId, e.getCause());
+        }
     }
 }

--- a/src/main/java/com/ureca/snac/trade/scheduler/TradeAutoProcessor.java
+++ b/src/main/java/com/ureca/snac/trade/scheduler/TradeAutoProcessor.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 @Slf4j
 @Component
-@Profile("scheduler")
+@Profile("!loadtest")
 @RequiredArgsConstructor
 public class TradeAutoProcessor {
 

--- a/src/main/java/com/ureca/snac/trade/scheduler/TradeDurationScheduler.java
+++ b/src/main/java/com/ureca/snac/trade/scheduler/TradeDurationScheduler.java
@@ -20,7 +20,7 @@ import static java.time.Duration.between;
 
 @Slf4j
 @Component
-@Profile("scheduler")
+@Profile("!loadtest")
 @RequiredArgsConstructor
 public class TradeDurationScheduler {
 

--- a/src/main/java/com/ureca/snac/trade/scheduler/TradeStatisticsScheduler.java
+++ b/src/main/java/com/ureca/snac/trade/scheduler/TradeStatisticsScheduler.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Slf4j
 @Component
-@Profile("scheduler")
+@Profile("!loadtest")
 @RequiredArgsConstructor
 public class TradeStatisticsScheduler {
 

--- a/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
+++ b/src/main/java/com/ureca/snac/trade/service/WebSocketTradeEventListener.java
@@ -41,7 +41,7 @@ import static com.ureca.snac.trade.entity.TradeStatus.PAYMENT_CONFIRMED;
 
 @Slf4j
 @Component
-@Profile("!scheduler")
+@Profile("!scheduler & !loadtest")
 @RequiredArgsConstructor
 public class WebSocketTradeEventListener {
 

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -1,0 +1,33 @@
+# 부하 테스트 전용 프로필 설정
+# 실행: java -jar app.jar --spring.profiles.active=loadtest
+
+spring:
+  main:
+    allow-bean-definition-overriding: true
+
+# Toss Mock 사용 (TossPaymentsClient 빈 생성 방지용 더미 값)
+payments:
+  toss:
+    url: "http://mock-unused"
+    secret-key: "mock-unused-key"
+
+# 장애 주입 설정
+loadtest:
+  fault:
+    deposit-failure-rate: 0.0     # 기본 비활성. Performance Test 시 JVM 인자로 활성화: -Dloadtest.fault.deposit-failure-rate=0.10
+    cancel-failure-rate: 0.0      # 기본 비활성. Performance Test 시 JVM 인자로 활성화: -Dloadtest.fault.cancel-failure-rate=0.02
+
+# 대사 스케줄러 부하 테스트에서 빠르게 동작하도록 조정
+reconciliation:
+  scheduler:
+    cron: "0 */2 * * * *"                  # 2분마다 실행
+    stale-threshold-minutes: 2             # 2분 이상 PENDING이면 대사 대상
+    batch-size: 100
+
+# Outbox Polling : 기본값 유지 (1초)
+outbox:
+  publisher:
+    fixed-delay-ms: 1000
+    max-retry: 300                        # RabbitMQ 장애 2분(120회 재시도) 이상 커버
+    batch-size: 100
+    stale-threshold-minutes: 1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -129,6 +129,9 @@ spring:
     port: ${RABBITMQ_PORT}
     username: ${RABBITMQ_USERNAME}
     password: ${RABBITMQ_PASSWORD}
+    # Publisher Confirms: 브로커 수신 확인 (Outbox 메시지 유실 방지)
+    publisher-confirm-type: correlated
+    publisher-returns: true
     # Connection Recovery 설정
     connection-timeout: 10000
     requested-heartbeat: 60             # 60초마다 하트비트


### PR DESCRIPTION
## 변경 사항 요약

부하 테스트 전용 loadtest 프로필 환경 구성 + Publisher Confirms 도입

Closes #29

---

## 주요 변경 사항

### 1. loadtest 프로필 환경

**LoadTestController, LoadTestService**
- 인증 우회 회원가입 API (`/api/loadtest/join`)
- 테스트 계정 생성 → 이벤트 체이닝(지갑 생성 + 가입 보너스)까지 검증 가능

**MockPaymentGatewayAdapter**
- Toss Payments API Mock (loadtest 프로필 전용)
- `cancel-failure-rate` 설정으로 취소 실패 장애 주입 지원

**FaultInjectionAspect**
- `MoneyDepositor.deposit()` AOP 장애 주입
- `deposit-failure-rate` 설정으로 DB 저장 실패 시뮬레이션 → Auto-Cancel 보상 트랜잭션 발동

**application-loadtest.yml**
- 장애 주입률 설정 (기본 비활성, JVM 인자로 활성화)
- 대사 스케줄러 2분 주기, Outbox max-retry 300 (5분 장애 커버)

### 2. Publisher Confirms

**OutboxMessagePublisher**
- `CorrelationData` 기반 브로커 ACK/NACK 대기 (5초 타임아웃)
- 확인 실패 시 `AmqpException` → `SEND_FAIL` → Outbox Polling 재시도

**RabbitMQConfig**
- `RabbitTemplate.setMandatory(true)` (라우팅 불가 메시지 반환 감지)

**application.yml**
- `publisher-confirm-type: correlated` + `publisher-returns: true`

### 3. loadtest 프로필 빈 충돌 방지

- `TossPaymentsAdapter`: `@Profile("!loadtest")` 추가
- WebSocket/STOMP 관련 빈: loadtest 제외
- 거래 스케줄러: loadtest 제외

---

## 동작 흐름

### Publisher Confirms 정상 흐름

```
Outbox 이벤트 발생 → convertAndSend() → CorrelationData.getFuture().get(5s)
→ 브로커 ACK 확인 → markAsPublished()
```

### Publisher Confirms 장애 복구 흐름

```
convertAndSend() → 브로커 NACK 또는 타임아웃
→ AmqpException → markAsFailed(SEND_FAIL)
→ OutboxPollingScheduler 1초 주기 재시도 → 브로커 복구 후 발행 성공
```

### 장애 주입 테스트 흐름 (CompensationTest)

```
충전 요청 → Toss 승인 OK → FaultInjectionAspect(10%) → DB 실패
→ Auto-Cancel (Toss 취소) → PaymentCancelCompensationEvent → Outbox
```

---

## 기술적 의사결정

### 왜 Publisher Confirms인가?

**문제**
- RabbitMQ 재시작 전환 구간에서 `convertAndSend()` 성공 반환하지만 메시지 미도달
- Outbox를 PUBLISHED로 마킹 → 이벤트 유실 (부하 테스트에서 Member 9,388건 vs Wallet 6,966건 갭 발견)

**해결**
- `publisher-confirm-type: correlated`로 브로커 수신 확인 후에만 PUBLISHED 처리
- 확인 실패 시 SEND_FAIL 유지 → Outbox Polling이 재시도

**검증 수치**
- Publisher Confirms 적용 후: Member:Wallet:SignupBonus = 4,938:4,938:4,938 (무손실)

### 왜 max-retry 300인가?

**문제**
- 기존 max-retry=10, 1초 polling → 10초 후 이벤트 포기 (SEND_FAIL 잔류)

**해결**
- max-retry=300 → 약 5분 장애 커버
- 프로덕션 환경변수 `OUTBOX_MAX_RETRY`도 300으로 조정