### PR TITLE
HikariCP 커넥션 풀 튜닝 (VU 300 병목 해소)

### DIFF
--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -4,6 +4,10 @@
 spring:
   main:
     allow-bean-definition-overriding: true
+  datasource:
+    hikari:
+      maximum-pool-size: 50
+      minimum-idle: 10
 
 # Toss Mock 사용 (TossPaymentsClient 빈 생성 방지용 더미 값)
 payments:


### PR DESCRIPTION
## 변경 사항 요약

부하 테스트 VU 300에서 HikariCP 커넥션 풀 고갈 병목 해소

Closes #35

---

## 주요 변경 사항

### 1. HikariCP 설정

**application-loadtest.yml**

- `maximum-pool-size: 50`, `minimum-idle: 10` 추가

---

## 기술적 의사결정

### 왜 50인가?

**문제**
- VU 300에서 기본 pool=10 → `waiting=121`, 11.2% 에러, TPS 23.8

**분석**
- Little's Law: VU 300 × 0.094s = 28.2 커넥션 필요
- 외부 API(Toss) 호출은 이미 `@Transactional` 밖으로 분리 (코드 레벨 최적화 여지 없음)
- 28.2 + 여유 버퍼 ≈ 50

**결과**
- TPS: 23.8 → 97.6 (4.1배 ↑)
- Error Rate: 11.2% → 0%