### PR TITLE
결제 취소 CANCEL_REQUESTED 상태 도입

### DIFF
--- a/src/main/java/com/ureca/snac/payment/entity/Payment.java
+++ b/src/main/java/com/ureca/snac/payment/entity/Payment.java
@@ -76,6 +76,14 @@ public class Payment extends BaseTimeEntity {
         this.status = PaymentStatus.SUCCESS;
     }
 
+    // 취소 의도 기록 (SUCCESS → CANCEL_REQUESTED)
+    public void requestCancellation() {
+        if (this.status != PaymentStatus.SUCCESS) {
+            throw new PaymentNotCancellableException();
+        }
+        this.status = PaymentStatus.CANCEL_REQUESTED;
+    }
+
     // 상태 취소
     public void cancel(String reason) {
         if (this.status == PaymentStatus.CANCELED) {

--- a/src/main/java/com/ureca/snac/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/ureca/snac/payment/entity/PaymentStatus.java
@@ -3,10 +3,12 @@ package com.ureca.snac.payment.entity;
 public enum PaymentStatus {
     PENDING,
     SUCCESS,
+    CANCEL_REQUESTED,
     CANCELED
     /*
      * PENDING: 결제 대기중
      * SUCCESS : 결제 성공
+     * CANCEL_REQUESTED : 결제 취소 요청 (토스 API 호출 전 의도 기록)
      * CANCELED : 결제 취소
      */
 }

--- a/src/main/java/com/ureca/snac/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/ureca/snac/payment/repository/PaymentRepository.java
@@ -68,4 +68,13 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     List<Payment> findStalePendingPayments(@Param("status") PaymentStatus status,
                                            @Param("threshold") LocalDateTime threshold,
                                            Pageable pageable);
+
+    /**
+     * 여러 상태의 stale 결제 건 조회 (PENDING, CANCEL_REQUESTED)
+     * updatedAt 사용: CANCEL_REQUESTED는 상태 변경 시점 기준으로 stale 판단
+     */
+    @Query("select p from Payment p join fetch p.member where p.status in :statuses and p.updatedAt < :threshold")
+    List<Payment> findStalePayments(@Param("statuses") List<PaymentStatus> statuses,
+                                    @Param("threshold") LocalDateTime threshold,
+                                    Pageable pageable);
 }

--- a/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationScheduler.java
+++ b/src/main/java/com/ureca/snac/payment/scheduler/PaymentReconciliationScheduler.java
@@ -8,6 +8,7 @@ import com.ureca.snac.payment.entity.PaymentStatus;
 import com.ureca.snac.payment.exception.TossRetryableException;
 import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.payment.service.PaymentAlertService;
+import com.ureca.snac.payment.service.PaymentInternalService;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +36,7 @@ public class PaymentReconciliationScheduler {
     private final PaymentRepository paymentRepository;
     private final PaymentGatewayAdapter paymentGatewayAdapter;
     private final PaymentReconciliationProcessor processor;
+    private final PaymentInternalService paymentInternalService;
     private final PaymentAlertService paymentAlertService;
     private final MeterRegistry meterRegistry;
     private final int staleThresholdMinutes;
@@ -44,6 +46,7 @@ public class PaymentReconciliationScheduler {
             PaymentRepository paymentRepository,
             PaymentGatewayAdapter paymentGatewayAdapter,
             PaymentReconciliationProcessor processor,
+            PaymentInternalService paymentInternalService,
             PaymentAlertService paymentAlertService,
             MeterRegistry meterRegistry,
             @Value("${reconciliation.scheduler.stale-threshold-minutes}") int staleThresholdMinutes,
@@ -52,6 +55,7 @@ public class PaymentReconciliationScheduler {
         this.paymentRepository = paymentRepository;
         this.paymentGatewayAdapter = paymentGatewayAdapter;
         this.processor = processor;
+        this.paymentInternalService = paymentInternalService;
         this.paymentAlertService = paymentAlertService;
         this.meterRegistry = meterRegistry;
         this.staleThresholdMinutes = staleThresholdMinutes;
@@ -63,8 +67,9 @@ public class PaymentReconciliationScheduler {
     public void reconcileStalePendingPayments() {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(staleThresholdMinutes);
 
-        List<Payment> stalePayments = paymentRepository.findStalePendingPayments(
-                PaymentStatus.PENDING, threshold, PageRequest.of(0, batchSize));
+        List<Payment> stalePayments = paymentRepository.findStalePayments(
+                List.of(PaymentStatus.PENDING, PaymentStatus.CANCEL_REQUESTED),
+                threshold, PageRequest.of(0, batchSize));
 
         if (stalePayments.isEmpty()) {
             log.debug("[대사] 문제된 결제 없음");
@@ -84,6 +89,14 @@ public class PaymentReconciliationScheduler {
     }
 
     private void reconcilePayment(Payment payment) {
+        if (payment.getStatus() == PaymentStatus.CANCEL_REQUESTED) {
+            reconcileCancelRequested(payment);
+            return;
+        }
+        reconcilePending(payment);
+    }
+
+    private void reconcilePending(Payment payment) {
         String orderId = payment.getOrderId();
 
         TossPaymentInquiryResponse tossResponse;
@@ -93,7 +106,6 @@ public class PaymentReconciliationScheduler {
             log.warn("[대사] 토스 조회 일시적 오류, 다음 주기에 재시도. orderId: {}", orderId);
             return;
         } catch (ExternalApiException e) {
-            // NOT_FOUND_PAYMENT 등 — 토스에 기록 없음, 로컬만 취소
             log.info("[대사] 토스에 결제 기록 없음. 로컬 취소 진행. orderId: {}", orderId);
             processor.cancelPayment(payment.getId(), "대사: 토스 결제 기록 없음 (orderId: " + orderId + ")");
             return;
@@ -107,6 +119,46 @@ public class PaymentReconciliationScheduler {
                     "대사: 토스 상태 " + tossResponse.status() + " (orderId: " + orderId + ")");
         } else {
             log.info("[대사] 토스 결제 진행 중 상태({}). 스킵. orderId: {}", tossResponse.status(), orderId);
+        }
+    }
+
+    private void reconcileCancelRequested(Payment payment) {
+        String paymentKey = payment.getPaymentKey();
+        String orderId = payment.getOrderId();
+        String cancelReason = "대사: CANCEL_REQUESTED 미완료 취소 복구 (orderId: " + orderId + ")";
+
+        TossPaymentInquiryResponse tossResponse;
+        try {
+            tossResponse = paymentGatewayAdapter.inquirePaymentByOrderId(orderId);
+        } catch (TossRetryableException e) {
+            log.warn("[대사] 토스 조회 일시적 오류, 다음 주기에 재시도. orderId: {}", orderId);
+            return;
+        } catch (ExternalApiException e) {
+            log.info("[대사] 토스에 결제 기록 없음. 취소 완료 처리 진행. orderId: {}", orderId);
+            paymentInternalService.completeCancellationForReconciliation(payment.getId(), cancelReason);
+            return;
+        }
+
+        if (tossResponse.isDone()) {
+            // 토스에서 아직 결제 상태 → 취소 API 호출 필요
+            try {
+                paymentGatewayAdapter.cancelPayment(paymentKey, cancelReason);
+            } catch (TossRetryableException e) {
+                log.warn("[대사] 토스 취소 일시적 오류, 다음 주기에 재시도. paymentKey: {}", paymentKey);
+                return;
+            } catch (ExternalApiException e) {
+                log.info("[대사] 토스 취소 API 예외 (이미 취소 가능). paymentKey: {}, error: {}",
+                        paymentKey, e.getMessage());
+            }
+        }
+        // 토스 CANCELED/DONE(취소 성공) 모두 → 로컬 취소 완료 처리
+        try {
+            paymentInternalService.completeCancellationForReconciliation(payment.getId(), cancelReason);
+            paymentAlertService.alertReconciliationAutoCanceled(payment, paymentKey);
+        } catch (Exception e) {
+            log.error("[대사] CANCEL_REQUESTED 취소 완료 실패! paymentId: {}, error: {}",
+                    payment.getId(), e.getMessage(), e);
+            paymentAlertService.alertReconciliationCancelFailed(payment, paymentKey, e.getMessage());
         }
     }
 

--- a/src/main/java/com/ureca/snac/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ureca/snac/payment/service/PaymentServiceImpl.java
@@ -66,6 +66,10 @@ public class PaymentServiceImpl implements PaymentService {
             payment.validateForCancellation(member);
             log.info("[결제 취소] 검증 통과");
 
+            // 취소 의도 기록 (SUCCESS → CANCEL_REQUESTED)
+            paymentInternalService.markAsCancelRequested(payment.getId());
+            log.info("[결제 취소] 취소 의도 DB 기록 완료");
+
             // 외부 API 호출 트랜잭션 외부니까
             log.info("[결제 취소] 외부 TOSS API 호출 시작. paymentKey : {}", paymentKey);
             PaymentCancelResponse cancelResponse =

--- a/src/test/java/com/ureca/snac/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/ureca/snac/payment/service/PaymentServiceTest.java
@@ -123,6 +123,8 @@ class PaymentServiceTest {
             paymentService.cancelPayment(PAYMENT_KEY, CANCEL_REASON, EMAIL);
 
             // then
+            verify(paymentInternalService, times(1))
+                    .markAsCancelRequested(successPayment.getId());
             verify(paymentGatewayAdapter, times(1))
                     .cancelPayment(PAYMENT_KEY, CANCEL_REASON);
             verify(paymentInternalService, times(1))


### PR DESCRIPTION
## 변경 사항 요약

Toss 취소 API 호출 전 취소 의도를 DB에 기록하여, JVM 크래시 시에도 대사 스케줄러가 미완료 취소를 감지하도록 개선

---

## 주요 변경 사항

### 1. 도메인 모델

**PaymentStatus**
- `CANCEL_REQUESTED` 상태 추가 (SUCCESS와 CANCELED 사이)

**Payment**
- `requestCancellation()` 메서드 추가 (SUCCESS → CANCEL_REQUESTED 전환)

### 2. 취소 플로우 변경

**PaymentServiceImpl**
- `cancelPayment()` 플로우에 `markAsCancelRequested` 단계 삽입 (Toss API 호출 전)

**PaymentInternalService**
- `markAsCancelRequested()` 추가 — FOR UPDATE 락 + requestCancellation()
- `completeCancellationForReconciliation()` 추가 — 대사용 취소 완료 (CANCELED 전환 + Wallet 회수 + AssetHistory 기록)

### 3. 대사 스케줄러 확장

**PaymentRepository**
- `findStalePayments(List<PaymentStatus>, threshold, pageable)` 쿼리 추가 (updatedAt 기준)

**PaymentReconciliationScheduler**
- PENDING + CANCEL_REQUESTED 동시 조회로 변경
- `reconcileCancelRequested()` 분기 추가: Toss 상태 확인 → 필요 시 Toss 취소 → completeCancellationForReconciliation

---

## 동작 흐름

### 정상 흐름 (변경 후)

```
사용자 취소 요청 → 검증 → SUCCESS → CANCEL_REQUESTED(DB 기록)
→ Toss 취소 API → CANCELED + Wallet 회수 + AssetHistory 기록
```

### 장애 복구 흐름

```
CANCEL_REQUESTED 상태에서 JVM 크래시
→ 대사 스케줄러 감지 (updatedAt 기준 stale)
→ Toss 상태 조회
  → DONE: Toss 취소 API → completeCancellationForReconciliation
  → CANCELED: completeCancellationForReconciliation (Toss 취소 스킵)
```

---

## 기술적 의사결정

### 왜 CANCEL_REQUESTED 중간 상태인가?

**문제**
- 기존: SUCCESS → (Toss 취소) → CANCELED. Toss 취소 성공 후 JVM 크래시 시 Payment가 SUCCESS로 남아 대사 스케줄러가 감지 불가

**해결**
- SUCCESS → CANCEL_REQUESTED → (Toss 취소) → CANCELED. 크래시해도 CANCEL_REQUESTED로 남아 대사가 감지

**비교**
- Toss 취소 후 보상 처리만 강화: 이미 보상 로직 존재하지만, JVM 크래시 시 보상 자체가 실행되지 않는 구간이 문제

### 왜 CANCEL_REQUESTED는 Processor가 아닌 PaymentInternalService에서 처리하는가?

**문제**
- PENDING 취소는 Wallet 회수 불필요 (충전 전이므로), CANCEL_REQUESTED 취소는 Wallet 회수 필요 (충전 후이므로)

**해결**
- PENDING → 기존 Processor.cancelPayment() (상태만 변경)
- CANCEL_REQUESTED → PaymentInternalService.completeCancellationForReconciliation() (상태 변경 + Wallet 회수 + AssetHistory)