### PR TITLE
[test] 회원가입 보너스 멱등성 동시성 통합 테스트

### DIFF
--- a/src/test/java/com/ureca/snac/integration/SignupBonusConcurrencyIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/SignupBonusConcurrencyIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.ureca.snac.integration;
+
+import com.ureca.snac.asset.entity.AssetHistory;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.wallet.entity.Wallet;
+import com.ureca.snac.wallet.service.SignupBonusService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("회원가입 보너스 멱등성 동시성 통합 테스트")
+class SignupBonusConcurrencyIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private SignupBonusService signupBonusService;
+
+    private static final int THREAD_COUNT = 50;
+
+    @Test
+    @DisplayName("동시성: 동일 memberId N건 동시 지급 -> Wallet 포인트 1회만 증가, AssetHistory 1건")
+    void shouldGrantBonusOnlyOnce() throws InterruptedException {
+        // given
+        Member member = createMemberWithWallet("bonus_");
+
+        // when: 50스레드 동시 호출
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger duplicateCount = new AtomicInteger();
+
+        runConcurrently(() -> {
+            try {
+                signupBonusService.grantSignupBonus(member.getId());
+                successCount.incrementAndGet();
+            } catch (DataIntegrityViolationException e) {
+                duplicateCount.incrementAndGet();
+            }
+        }, THREAD_COUNT);
+
+        // then
+        // 1. Wallet 포인트 1000 (1회만 입금)
+        Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+        assertThat(wallet.getPointBalance()).isEqualTo(1000L);
+
+        // 2. AssetHistory 1건만 (idempotencyKey unique 보장)
+        List<AssetHistory> histories = assetHistoryRepository.findAll();
+        assertThat(histories).hasSize(1);
+        assertThat(histories.get(0).getIdempotencyKey())
+                .isEqualTo("SIGNUP_BONUS:" + member.getId());
+
+        // 3. 전체 = 성공 + 중복 (예외 누출 없음)
+        assertThat(successCount.get() + duplicateCount.get()).isEqualTo(THREAD_COUNT);
+        assertThat(successCount.get()).isGreaterThanOrEqualTo(1);
+    }
+
+    private void runConcurrently(Runnable task, int threadCount) throws InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    latch.await();
+                    task.run();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+        }
+
+        latch.countDown();
+
+        for (Future<?> future : futures) {
+            try {
+                future.get(30, TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException ignored) {
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(45, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
## 변경 사항 요약

회원가입 보너스 이벤트 중복 수신 시 멱등성 동시성 통합 테스트 추가

---

## 주요 변경 사항

### 1. 동시성 통합 테스트

**SignupBonusConcurrencyIntegrationTest**

- 50스레드 CountDownLatch 동시 호출 패턴
- Wallet 포인트 1회만 증가 검증
- AssetHistory 1건만 생성 검증 (idempotencyKey unique)
- 전체 스레드 정상 종료 확인

---

## 동작 흐름

### 정상 흐름 (1건 성공)
```
grantSignupBonus -> isAlreadyGranted(false) -> depositPoint
-> recordSignupBonus -> AssetHistory(unique key) -> 완료
```

### 동시성 방어 흐름 (N-1건 차단)
```
대부분: isAlreadyGranted(true) -> 조기 반환
동시 통과: INSERT -> unique 제약 위반
-> DataIntegrityViolationException -> 트랜잭션 롤백
```

---

## 기술적 의사결정

### 왜 이중 방어(Application + DB)인가?

**문제**
- Application 계층 isAlreadyGranted()만으로는 동시 통과 가능

**해결**
- DB unique 제약으로 최종 방어, 트랜잭션 롤백으로 데이터 정합성 보장

**비교**
- 단일 계층: 동시성에서 뚫림 (read-then-write race condition)