### PR TITLE
[chore] AWS 부하 테스트 설정 보정

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -6,7 +6,7 @@
 |------|------------|--------|-------------------|
 | **MySQL** | t3.medium | MySQL 8.0 | 3306 (App EC2) |
 | **RabbitMQ + Redis** | t3.medium | RabbitMQ, Redis | 5672, 15672, 61613, 6379 (App EC2) |
-| **Pinpoint** | t3.large | HBase, Collector, Web | 9991-9995 (App EC2), 28080 (내 IP) |
+| **Pinpoint** | t3.large | HBase, Collector, Web | 9991-9995 (App EC2), 8080 (내 IP) |
 | **App (SUT)** | t3.medium | Spring Boot + Pinpoint Agent | 8080 (nGrinder EC2, Monitoring EC2) |
 | **Monitoring** | t3.small | Prometheus, Grafana | 9090, 3000 (내 IP) |
 | **nGrinder** | t3.medium | Controller, Agent | 9000 (내 IP) |
@@ -98,7 +98,7 @@ docker compose -f aws/pinpoint/docker-compose.yml up -d
 
 확인 (HBase 초기화에 1~2분 소요):
 ```bash
-curl -s http://localhost:28080 | head -1
+curl -s http://localhost:8080 | head -1
 ```
 
 ### Step 4: App EC2 — 1차 기동 (테이블 생성)

--- a/aws/app/docker-compose.yml
+++ b/aws/app/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ../.env
     environment:
       - SPRING_PROFILES_ACTIVE=loadtest
-      - JAVA_OPTS=-Xms512m -Xmx1g -javaagent:/pinpoint-agent/pinpoint-bootstrap-2.5.4.jar -Dpinpoint.agentId=snac-app-1 -Dpinpoint.applicationName=snac-backend -Dprofiler.transport.grpc.collector.ip=172.31.11.198 -Dprofiler.collector.ip=172.31.11.198
+      - JAVA_OPTS=-Xms512m -Xmx1g -javaagent:/pinpoint-agent/pinpoint-bootstrap-2.5.4.jar -Dpinpoint.agentId=snac-app-1 -Dpinpoint.applicationName=snac-backend -Dprofiler.transport.grpc.collector.ip=${PINPOINT_IP} -Dprofiler.collector.ip=${PINPOINT_IP}
     volumes:
       - ./app.jar:/app/app.jar
       - pinpoint_agent:/pinpoint-agent

--- a/aws/env.example
+++ b/aws/env.example
@@ -29,6 +29,12 @@ STOMP_CLIENT_LOGIN=guest
 STOMP_PORT=61613
 STOMP_HOST={REDIS_RABBITMQ_IP}
 
+# ─── Pinpoint ───
+PINPOINT_IP={PINPOINT_IP}
+
+# ─── App (Prometheus target) ───
+APP_IP={APP_IP}
+
 # ─── Toss Payments (테스트 키) ───
 TOSS_SECRET_KEY=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
 

--- a/aws/ngrinder/Dockerfile.agent
+++ b/aws/ngrinder/Dockerfile.agent
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jre-focal
 
-COPY agent.tar /tmp/agent.tar
+COPY ngrinder/agent/agent.tar /tmp/agent.tar
 RUN tar -xf /tmp/agent.tar -C /opt && rm /tmp/agent.tar
 
 RUN sed -i 's/agent.controller_host=.*/agent.controller_host=controller/' \

--- a/aws/ngrinder/docker-compose.yml
+++ b/aws/ngrinder/docker-compose.yml
@@ -13,8 +13,8 @@ services:
 
   agent:
     build:
-      context: .
-      dockerfile: Dockerfile.agent
+      context: ../../
+      dockerfile: aws/ngrinder/Dockerfile.agent
     container_name: snac-ngrinder-agent
     depends_on:
       - controller

--- a/aws/pinpoint/docker-compose.yml
+++ b/aws/pinpoint/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pinpoint-hbase:
-    image: pinpointdocker/pinpoint-hbase:3.0.0
+    image: pinpointdocker/pinpoint-hbase:2.5.4
     container_name: pinpoint-hbase
     ports:
       - "16010:16010"
@@ -10,7 +10,7 @@ services:
       - hbase_zk_data:/home/pinpoint/zookeeper
 
   pinpoint-collector:
-    image: pinpointdocker/pinpoint-collector:3.0.0
+    image: pinpointdocker/pinpoint-collector:2.5.4
     container_name: pinpoint-collector
     restart: on-failure
     depends_on:
@@ -29,13 +29,13 @@ services:
       - FLINK_CLUSTER_ENABLE=false
 
   pinpoint-web:
-    image: pinpointdocker/pinpoint-web:3.0.0
+    image: pinpointdocker/pinpoint-web:2.5.4
     container_name: pinpoint-web
     restart: on-failure
     depends_on:
       - pinpoint-hbase
     ports:
-      - "28080:8080"
+      - "8080:8080"
     environment:
       - CLUSTER_ENABLE=false
       - HBASE_HOST=pinpoint-hbase


### PR DESCRIPTION
## 변경 사항 요약

AWS 부하 테스트 재실행을 위한 설정 파일 보정

---

## 주요 변경 사항

### 1. Pinpoint

- 이미지 3.0.0 → 2.5.4 (이전 테스트 환경 일치)
- Web UI 포트 28080 → 8080 (보안그룹 일치)

### 2. 환경변수 처리

- Pinpoint IP 하드코딩 제거, env 참조로 변경
- nGrinder agent build context 경로 수정