### PR TITLE
[chore] 부하 테스트 설정 보정 및 동시성 테스트 스레드 상향

### DIFF
--- a/aws/app/docker-compose.yml
+++ b/aws/app/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ../.env
     environment:
       - SPRING_PROFILES_ACTIVE=loadtest
-      - JAVA_OPTS=-Xms512m -Xmx1g -javaagent:/pinpoint-agent/pinpoint-bootstrap-2.5.4.jar -Dpinpoint.agentId=snac-app-1 -Dpinpoint.applicationName=snac-backend -Dprofiler.transport.grpc.collector.ip=${PINPOINT_IP} -Dprofiler.collector.ip=${PINPOINT_IP}
+      - JAVA_OPTS=-Xms512m -Xmx1g -javaagent:/pinpoint-agent/pinpoint-bootstrap-2.5.4.jar -Dpinpoint.agentId=snac-app-1 -Dpinpoint.applicationName=snac-backend -Dprofiler.transport.grpc.collector.ip=${PINPOINT_IP} -Dprofiler.collector.ip=${PINPOINT_IP} -Dloadtest.fault.deposit-failure-rate=0.10 -Dloadtest.fault.cancel-failure-rate=0.02
     volumes:
       - ./app.jar:/app/app.jar
       - pinpoint_agent:/pinpoint-agent

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -1,13 +1,18 @@
 # 부하 테스트 전용 프로필 설정
 # 실행: java -jar app.jar --spring.profiles.active=loadtest
 
+server:
+  tomcat:
+    threads:
+      max: 100
+
 spring:
   main:
     allow-bean-definition-overriding: true
   datasource:
     hikari:
-      maximum-pool-size: 50
-      minimum-idle: 10
+      maximum-pool-size: 20
+      minimum-idle: 20
 
 # Toss Mock 사용 (TossPaymentsClient 빈 생성 방지용 더미 값)
 payments:

--- a/src/test/java/com/ureca/snac/integration/SignupBonusConcurrencyIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/SignupBonusConcurrencyIntegrationTest.java
@@ -23,7 +23,7 @@ class SignupBonusConcurrencyIntegrationTest extends IntegrationTestSupport {
     @Autowired
     private SignupBonusService signupBonusService;
 
-    private static final int THREAD_COUNT = 50;
+    private static final int THREAD_COUNT = 100;
 
     @Test
     @DisplayName("동시성: 동일 memberId N건 동시 지급 -> Wallet 포인트 1회만 증가, AssetHistory 1건")
@@ -56,6 +56,7 @@ class SignupBonusConcurrencyIntegrationTest extends IntegrationTestSupport {
                 .isEqualTo("SIGNUP_BONUS:" + member.getId());
 
         // 3. 전체 = 성공 + 중복 (예외 누출 없음)
+        System.out.println("[멱등성 결과] 성공: " + successCount.get() + "건, DB 차단(unique 위반): " + duplicateCount.get() + "건, 총: " + THREAD_COUNT + "건");
         assertThat(successCount.get() + duplicateCount.get()).isEqualTo(THREAD_COUNT);
         assertThat(successCount.get()).isGreaterThanOrEqualTo(1);
     }


### PR DESCRIPTION
## 변경 사항 요약

AWS 부하 테스트 환경 설정 보정 및 동시성 테스트 스레드 100 상향

---

## 주요 변경 사항

### 1. AWS 부하 테스트 환경

**docker-compose.yml**
- fault injection JVM 옵션 추가 (deposit-failure-rate=0.10, cancel-failure-rate=0.02)

**application-loadtest.yml**
- Tomcat 스레드 max=100 설정
- HikariCP maximum-pool-size=20, minimum-idle=20 보정

### 2. 동시성 테스트

**SignupBonusConcurrencyIntegrationTest**
- THREAD_COUNT 50 → 100 상향
- 멱등성 결과 로그 출력 추가