### PR TITLE
이벤트 중복 수신 멱등성 및 충전 동시성 검증 테스트 추가

### DIFF
--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositor.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositor.java
@@ -8,6 +8,7 @@ import com.ureca.snac.money.repository.MoneyRechargeRepository;
 import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.entity.PaymentMethod;
 import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.PaymentAlreadyProcessedPaymentException;
 import com.ureca.snac.payment.exception.PaymentNotFoundException;
 import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.wallet.service.WalletService;
@@ -52,11 +53,11 @@ public class MoneyDepositor {
         Payment lockedPayment = paymentRepository.findByIdForUpdate(payment.getId())
                 .orElseThrow(PaymentNotFoundException::new);
 
-        // 락 획득 후 상태 확인 - 이미 처리된 경우 조기 종료
+        // 락 획득 후 상태 확인 - 이미 처리된 경우 예외 (HTTP 4xx)
         if (lockedPayment.getStatus() != PaymentStatus.PENDING) {
             log.warn("[머니 입금 처리] 이미 처리된 결제. 중복 처리 방지. paymentId: {}, status: {}",
                     payment.getId(), lockedPayment.getStatus());
-            return;
+            throw new PaymentAlreadyProcessedPaymentException();
         }
 
         // 락이 걸린 영속 객체를 사용하여 모든 작업 수행

--- a/src/test/java/com/ureca/snac/integration/BrokerRetransmissionIdempotencyIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/BrokerRetransmissionIdempotencyIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.ureca.snac.integration;
+
+import com.ureca.snac.asset.entity.AssetHistory;
+import com.ureca.snac.config.RabbitMQQueue;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.support.fixture.EventFixture;
+import com.ureca.snac.wallet.entity.Wallet;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * 브로커 재전송 멱등성 통합 테스트
+ * <p>
+ * RabbitMQ at-least-once 전달 보장으로 인해 동일 메시지가 여러 번 수신될 수 있음.
+ * 멱등키 사전 조회로 포인트 지급은 1회만, 자산 내역도 1건만 기록되는지 검증.
+ */
+@DisplayName("브로커 재전송 멱등성 통합 테스트")
+class BrokerRetransmissionIdempotencyIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @Test
+    @DisplayName("브로커 재전송 시나리오: 동일 메시지 2회 수신 → 포인트 1회만 지급, 자산 내역 1건")
+    void shouldGrantBonusOnlyOnce_WhenSameMessageDeliveredTwice() {
+        // given
+        Member member = createMemberWithWallet("redelivery_");
+        Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+        String payload = EventFixture.walletCreatedEventJson(member.getId(), wallet.getId());
+
+        // 컨텍스트 재사용 대응: 전송 전 카운터 스냅샷
+        Counter counter = meterRegistry.counter(
+                "listener_message_processed_total",
+                "queue", RabbitMQQueue.WALLET_CREATED_QUEUE,
+                "result", "success"
+        );
+        double before = counter.count();
+
+        // when: 동일 payload 2회 전송 (브로커 재전송 시뮬레이션)
+        rabbitTemplate.convertAndSend(RabbitMQQueue.WALLET_CREATED_QUEUE, payload);
+        rabbitTemplate.convertAndSend(RabbitMQQueue.WALLET_CREATED_QUEUE, payload);
+
+        // then: 두 메시지 모두 처리 완료 대기
+        await().atMost(10, SECONDS).untilAsserted(() ->
+                assertThat(counter.count()).isEqualTo(before + 2)
+        );
+
+        // 포인트: 1000 (1회만 입금)
+        Wallet updated = walletRepository.findByMemberId(member.getId()).orElseThrow();
+        assertThat(updated.getPointBalance()).isEqualTo(1000L);
+
+        // 자산 내역: 1건 (멱등키 unique 제약으로 이중 반영 차단)
+        assertThat(assetHistoryRepository.findAll())
+                .hasSize(1)
+                .first()
+                .extracting(AssetHistory::getIdempotencyKey)
+                .isEqualTo("SIGNUP_BONUS:" + member.getId());
+    }
+}

--- a/src/test/java/com/ureca/snac/outbox/repository/OutboxRepositoryTest.java
+++ b/src/test/java/com/ureca/snac/outbox/repository/OutboxRepositoryTest.java
@@ -85,6 +85,25 @@ class OutboxRepositoryTest extends RepositoryTestSupport {
         }
 
         @Test
+        @DisplayName("이중 발행 방어: Push·Polling 연속 호출 시 첫 번째만 성공(1), 두 번째는 no-op(0)")
+        void markAsPublished_consecutiveCalls_onlyFirstSucceeds() {
+            // given: INIT
+            Outbox outbox = OutboxFixture.memberJoinInit(1L);
+            outboxRepository.save(outbox);
+            outboxRepository.flush();
+
+            // when: Push
+            int firstResult = outboxRepository.markAsPublished(outbox.getId(), LocalDateTime.now());
+
+            // when: Polling
+            int secondResult = outboxRepository.markAsPublished(outbox.getId(), LocalDateTime.now());
+
+            // then
+            assertThat(firstResult).isEqualTo(1);
+            assertThat(secondResult).isEqualTo(0);
+        }
+
+        @Test
         @DisplayName("실패 : 이미 PUBLISHED 상태는 업데이트 실패")
         void markAsPublished_alreadyPublished_updateFails() {
             // given


### PR DESCRIPTION
## 변경 사항 요약

이벤트 중복 수신 멱등성 통합 테스트, Outbox 레포지토리 슬라이스 테스트, 충전 중복 요청 예외 처리 추가

Closes #45

---

## 주요 변경 사항

### 1. 멱등성 통합 테스트

**BrokerRetransmissionIdempotencyIntegrationTest**

- 브로커 재전송 시나리오: 동일 메시지 2회 수신 시 포인트 1회만 지급, 자산 내역 1건 검증
- 멱등키 사전 조회 및 unique 제약 이중 방어 동작 검증

### 2. Outbox 레포지토리 슬라이스 테스트

**OutboxRepositoryTest**

- markAsPublished, markAsFailedAndIncrementRetry, findPendingEvents, deleteOldPublishedEvents 테스트
- 이중 발행 방어: Push·Polling 연속 호출 시 첫 번째만 성공(1), 두 번째 no-op(0) 검증
- 멱등성: 동일 eventId 중복 저장 시 DataIntegrityViolationException 발생 검증

### 3. 충전 중복 처리 예외 반환

**MoneyDepositor**

- 이미 처리된 Payment 조기 반환(return) → PaymentAlreadyProcessedPaymentException 예외로 변경 (HTTP 4xx)

---

## 동작 흐름

### 브로커 재전송 멱등성 흐름

```
동일 메시지 2회 수신
→ 1회: 멱등키 사전 조회 미존재 → 포인트 지급 → AssetHistory 저장
→ 2회: 멱등키 사전 조회 존재 → 조기 반환 (이중 반영 차단)
→ 결과: 포인트 1000, 자산 내역 1건
```

### 충전 중복 요청 흐름

```
동시 충전 요청
→ 비관적 락 획득 후 Payment 상태 확인
→ PENDING 아님 → PaymentAlreadyProcessedPaymentException (HTTP 4xx)
```