### PR TITLE
[refactor] ObjectMapper 생성자 주입 전환 및 이중 @Async 제거

### DIFF
--- a/src/main/java/com/ureca/snac/infra/TossPaymentsErrorHandler.java
+++ b/src/main/java/com/ureca/snac/infra/TossPaymentsErrorHandler.java
@@ -5,11 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ureca.snac.common.exception.ExternalApiException;
 import com.ureca.snac.infra.dto.response.TossErrorResponse;
 import com.ureca.snac.payment.exception.*;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.ResponseErrorHandler;
+
+import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 import java.net.URI;
@@ -22,9 +23,10 @@ import static com.ureca.snac.common.BaseCode.TOSS_API_CALL_ERROR;
  * API를 호출하는 CLIENT 코드는 에러 처리 로직으로부터 분리
  */
 @Slf4j
+@RequiredArgsConstructor
 public class TossPaymentsErrorHandler implements ResponseErrorHandler {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Override
     public boolean hasError(final ClientHttpResponse response) throws IOException {
@@ -33,8 +35,8 @@ public class TossPaymentsErrorHandler implements ResponseErrorHandler {
     }
 
     @Override
-    public void handleError(@NonNull final URI url,
-                            @NonNull final HttpMethod method,
+    public void handleError(final URI url,
+                            final HttpMethod method,
                             final ClientHttpResponse response) throws IOException {
         String responseBody = new String(response.getBody().readAllBytes(),
                 StandardCharsets.UTF_8);

--- a/src/main/java/com/ureca/snac/infra/config/TossRestClientConfig.java
+++ b/src/main/java/com/ureca/snac/infra/config/TossRestClientConfig.java
@@ -1,5 +1,6 @@
 package com.ureca.snac.infra.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ureca.snac.infra.TossPaymentsErrorHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -24,8 +25,8 @@ public class TossRestClientConfig {
     private final RestClient.Builder restClientBuilder;  // 공통 빌더 주입
 
     @Bean
-    public TossPaymentsErrorHandler tossPaymentsErrorHandler() {
-        return new TossPaymentsErrorHandler();
+    public TossPaymentsErrorHandler tossPaymentsErrorHandler(ObjectMapper objectMapper) {
+        return new TossPaymentsErrorHandler(objectMapper);
     }
 
     @Bean
@@ -35,7 +36,7 @@ public class TossRestClientConfig {
 
     @Bean
     public RestClient tossRestClient(TossPaymentsErrorHandler errorHandler,
-                                      TossLoggingInterceptor loggingInterceptor) {
+                                     TossLoggingInterceptor loggingInterceptor) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(Duration.ofSeconds(5));
         requestFactory.setReadTimeout(Duration.ofSeconds(30));

--- a/src/main/java/com/ureca/snac/payment/listener/CriticalPaymentFailureAlertListener.java
+++ b/src/main/java/com/ureca/snac/payment/listener/CriticalPaymentFailureAlertListener.java
@@ -1,13 +1,10 @@
 package com.ureca.snac.payment.listener;
 
-import com.ureca.snac.config.AsyncConfig;
 import com.ureca.snac.payment.event.alert.AutoCancelFailureEvent;
 import com.ureca.snac.payment.event.alert.CompensationFailureEvent;
-import com.ureca.snac.payment.event.alert.CriticalPaymentFailureEvent;
 import com.ureca.snac.payment.service.PaymentAlertService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -15,8 +12,8 @@ import org.springframework.transaction.event.TransactionalEventListener;
 /**
  * 결제 관련 치명적 실패 이벤트 통합 리스너
  * <p>
- * 비동기로 Slack 알림 발송 (메인 트랜잭션에 영향 없음)
  * AFTER_COMPLETION: commit/rollback 무관하게 실행
+ * 메시지 조립은 동기, 실제 HTTP 전송은 SlackNotifier.sendAsync()에서 비동기 처리
  */
 @Slf4j
 @Component
@@ -25,15 +22,19 @@ public class CriticalPaymentFailureAlertListener {
 
     private final PaymentAlertService paymentAlertService;
 
-    @Async(AsyncConfig.NOTIFICATION_EXECUTOR_NAME)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
-    public void handleCriticalFailure(CriticalPaymentFailureEvent event) {
+    public void handleAutoCancelFailure(AutoCancelFailureEvent event) {
         try {
-            if (event instanceof AutoCancelFailureEvent e) {
-                paymentAlertService.alertAutoCancelFailure(e);
-            } else if (event instanceof CompensationFailureEvent e) {
-                paymentAlertService.alertCompensationFailure(e);
-            }
+            paymentAlertService.alertAutoCancelFailure(event);
+        } catch (Exception e) {
+            log.error("[CRITICAL ALERT FAILURE] 알림 발송 실패. paymentId: {}", event.paymentId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
+    public void handleCompensationFailure(CompensationFailureEvent event) {
+        try {
+            paymentAlertService.alertCompensationFailure(event);
         } catch (Exception e) {
             log.error("[CRITICAL ALERT FAILURE] 알림 발송 실패. paymentId: {}", event.paymentId(), e);
         }

--- a/src/test/java/com/ureca/snac/infra/TossPaymentsErrorHandlerTest.java
+++ b/src/test/java/com/ureca/snac/infra/TossPaymentsErrorHandlerTest.java
@@ -30,7 +30,7 @@ class TossPaymentsErrorHandlerTest {
 
     @BeforeEach
     void setUp() {
-        errorHandler = new TossPaymentsErrorHandler();
+        errorHandler = new TossPaymentsErrorHandler(objectMapper);
     }
 
     @Nested

--- a/src/test/java/com/ureca/snac/payment/listener/CriticalPaymentFailureAlertListenerTest.java
+++ b/src/test/java/com/ureca/snac/payment/listener/CriticalPaymentFailureAlertListenerTest.java
@@ -18,7 +18,8 @@ import static org.mockito.BDDMockito.verify;
 
 /**
  * CriticalPaymentFailureAlertListener 단위 테스트
- * handleCriticalFailure: 치명적 실패 이벤트 처리 및 Slack 알림 발송
+ * handleAutoCancelFailure, handleCompensationFailure
+ * 치명적 실패 이벤트 처리 및 Slack 알림 발송
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CriticalPaymentFailureAlertListenerTest 단위 테스트")
@@ -37,109 +38,104 @@ class CriticalPaymentFailureAlertListenerTest {
     private static final String PAYMENT_KEY = "test_payment_key";
 
     @Nested
-    @DisplayName("handleCriticalFailure 메서드")
-    class HandleCriticalFailureTest {
+    @DisplayName("handleAutoCancelFailure 메서드")
+    class HandleAutoCancelFailureTest {
 
-        @Nested
-        @DisplayName("AutoCancelFailureEvent 처리")
-        class AutoCancelFailureEventTest {
+        @Test
+        @DisplayName("정상 : AutoCancelFailureEvent 수신 시 alertAutoCancelFailure 호출")
+        void handleAutoCancelFailure_CallsAlertService() {
+            // given
+            AutoCancelFailureEvent event = new AutoCancelFailureEvent(
+                    PAYMENT_ID,
+                    MEMBER_ID,
+                    AMOUNT,
+                    ORDER_ID,
+                    PAYMENT_KEY,
+                    "DB Connection Failed",
+                    "Toss Cancel API Failed"
+            );
 
-            @Test
-            @DisplayName("정상 : AutoCancelFailureEvent 수신 시 alertAutoCancelFailure 호출")
-            void handleCriticalFailure_AutoCancelEvent_CallsAlertService() {
-                // given
-                AutoCancelFailureEvent event = new AutoCancelFailureEvent(
-                        PAYMENT_ID,
-                        MEMBER_ID,
-                        AMOUNT,
-                        ORDER_ID,
-                        PAYMENT_KEY,
-                        "DB Connection Failed",
-                        "Toss Cancel API Failed"
-                );
+            // when
+            listener.handleAutoCancelFailure(event);
 
-                // when
-                listener.handleCriticalFailure(event);
-
-                // then
-                verify(paymentAlertService).alertAutoCancelFailure(event);
-            }
-
-            @Test
-            @DisplayName("예외 처리 : alertAutoCancelFailure 실패해도 예외 전파 않음")
-            void handleCriticalFailure_AutoCancelEvent_SwallowsException() {
-                // given
-                AutoCancelFailureEvent event = new AutoCancelFailureEvent(
-                        PAYMENT_ID,
-                        MEMBER_ID,
-                        AMOUNT,
-                        ORDER_ID,
-                        PAYMENT_KEY,
-                        "DB Error",
-                        "Cancel Error"
-                );
-                doThrow(new RuntimeException("Slack API Failed"))
-                        .when(paymentAlertService).alertAutoCancelFailure(event);
-
-                // when & then: 예외 발생하지 않음
-                listener.handleCriticalFailure(event);
-
-                // verify: 호출은 됨
-                verify(paymentAlertService).alertAutoCancelFailure(event);
-            }
+            // then
+            verify(paymentAlertService).alertAutoCancelFailure(event);
         }
 
-        @Nested
-        @DisplayName("CompensationFailureEvent 처리")
-        class CompensationFailureEventTest {
+        @Test
+        @DisplayName("예외 처리 : alertAutoCancelFailure 실패해도 예외 전파 않음")
+        void handleAutoCancelFailure_SwallowsException() {
+            // given
+            AutoCancelFailureEvent event = new AutoCancelFailureEvent(
+                    PAYMENT_ID,
+                    MEMBER_ID,
+                    AMOUNT,
+                    ORDER_ID,
+                    PAYMENT_KEY,
+                    "DB Error",
+                    "Cancel Error"
+            );
+            doThrow(new RuntimeException("Slack API Failed"))
+                    .when(paymentAlertService).alertAutoCancelFailure(event);
 
-            @Test
-            @DisplayName("정상 : CompensationFailureEvent 수신 시 alertCompensationFailure 호출")
-            void handleCriticalFailure_CompensationEvent_CallsAlertService() {
-                // given
-                CompensationFailureEvent event = new CompensationFailureEvent(
-                        PAYMENT_ID,
-                        MEMBER_ID,
-                        AMOUNT,
-                        ORDER_ID,
-                        PAYMENT_KEY,
-                        "고객 요청 취소",
-                        OffsetDateTime.now(),
-                        "Original DB Error",
-                        "Compensation DB Error"
-                );
+            // when & then: 예외 발생하지 않음
+            listener.handleAutoCancelFailure(event);
 
-                // when
-                listener.handleCriticalFailure(event);
+            // verify: 호출은 됨
+            verify(paymentAlertService).alertAutoCancelFailure(event);
+        }
+    }
 
-                // then
-                verify(paymentAlertService).alertCompensationFailure(event);
-            }
+    @Nested
+    @DisplayName("handleCompensationFailure 메서드")
+    class HandleCompensationFailureTest {
 
-            @Test
-            @DisplayName("예외 처리 : alertCompensationFailure 실패해도 예외 전파 않음")
-            void handleCriticalFailure_CompensationEvent_SwallowsException() {
-                // given
-                CompensationFailureEvent event = new CompensationFailureEvent(
-                        PAYMENT_ID,
-                        MEMBER_ID,
-                        AMOUNT,
-                        ORDER_ID,
-                        PAYMENT_KEY,
-                        "취소 사유",
-                        OffsetDateTime.now(),
-                        "Original Error",
-                        "Compensation Error"
-                );
-                doThrow(new RuntimeException("Slack API Failed"))
-                        .when(paymentAlertService).alertCompensationFailure(event);
+        @Test
+        @DisplayName("정상 : CompensationFailureEvent 수신 시 alertCompensationFailure 호출")
+        void handleCompensationFailure_CallsAlertService() {
+            // given
+            CompensationFailureEvent event = new CompensationFailureEvent(
+                    PAYMENT_ID,
+                    MEMBER_ID,
+                    AMOUNT,
+                    ORDER_ID,
+                    PAYMENT_KEY,
+                    "고객 요청 취소",
+                    OffsetDateTime.now(),
+                    "Original DB Error",
+                    "Compensation DB Error"
+            );
 
-                // when & then: 예외 발생하지 않음
-                listener.handleCriticalFailure(event);
+            // when
+            listener.handleCompensationFailure(event);
 
-                // verify: 호출은 됨
-                verify(paymentAlertService).alertCompensationFailure(event);
-            }
+            // then
+            verify(paymentAlertService).alertCompensationFailure(event);
+        }
+
+        @Test
+        @DisplayName("예외 처리 : alertCompensationFailure 실패해도 예외 전파 않음")
+        void handleCompensationFailure_SwallowsException() {
+            // given
+            CompensationFailureEvent event = new CompensationFailureEvent(
+                    PAYMENT_ID,
+                    MEMBER_ID,
+                    AMOUNT,
+                    ORDER_ID,
+                    PAYMENT_KEY,
+                    "취소 사유",
+                    OffsetDateTime.now(),
+                    "Original Error",
+                    "Compensation Error"
+            );
+            doThrow(new RuntimeException("Slack API Failed"))
+                    .when(paymentAlertService).alertCompensationFailure(event);
+
+            // when & then: 예외 발생하지 않음
+            listener.handleCompensationFailure(event);
+
+            // verify: 호출은 됨
+            verify(paymentAlertService).alertCompensationFailure(event);
         }
     }
 }


### PR DESCRIPTION
## 변경 사항 요약

TossPayments 클라이언트 ObjectMapper 스프링 빈 주입 전환, 결제 실패 알림 리스너 구조 개선

Closes #47

---

## 주요 변경 사항

### 1. ObjectMapper 빈 주입

**TossPaymentsErrorHandler**

- `new ObjectMapper()` 직접 생성 → 생성자 주입으로 전환

**TossRestClientConfig**

- `RestClient` 빌더에 주입받은 `ObjectMapper` 전달

### 2. 결제 실패 알림 리스너 구조 개선

**CriticalPaymentFailureAlertListener**

- `@Async` 제거: 비동기 HTTP 전송 책임이 `SlackNotifier.sendAsync()`로 이동하여 리스너 레벨 `@Async` 불필요
- `CriticalPaymentFailureEvent` + `instanceof` 분기 단일 메서드 → `AutoCancelFailureEvent`, `CompensationFailureEvent` 타입별 전용 메서드로 분리

---

## 기술적 의사결정

### 왜 ObjectMapper를 빈으로 주입하는가?

**문제**
- `new ObjectMapper()` 호출 시 매 요청마다 새 인스턴스 생성
- `ObjectMapper`는 스레드 안전하며 재사용을 권장하는 heavy 객체

**해결**
- 스프링이 관리하는 싱글턴 빈을 생성자 주입으로 공유

**비교**
- static 필드: 스프링 컨텍스트 외부에서 관리되어 설정 커스터마이징 어려움

### 왜 리스너 @Async를 제거하는가?

**문제**
- 비동기 처리가 리스너 레벨(`@Async`)과 전송 레벨(`SlackNotifier.sendAsync()`) 두 곳에 존재
- 책임이 분산되어 흐름 추적 어려움

**해결**
- 리스너는 동기로 메시지 조립, 실제 HTTP 전송만 `SlackNotifier.sendAsync()`에서 비동기 처리

**비교**
- 리스너 `@Async` 유지: Slack 전송 외 다른 I/O가 생길 경우 리스너가 다시 비동기를 관리해야 하는 책임 증가