### PR TITLE
[feat] Wallet 에스크로 복합 메서드 통합 및 검증 조건 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ jacocoTestReport {
                             "**/com/ureca/snac/money/**",
                             "**/com/ureca/snac/outbox/**",
                             "**/com/ureca/snac/payment/**",
-                            "**/com/ureca/snac/wallet/listener/**"
+                            "**/com/ureca/snac/wallet/**"
                     ],
                     // 2. 테스트 없는 계층 + 단순 데이터/생성 클래스 제외
                     excludes: [
@@ -170,7 +170,7 @@ jacocoTestCoverageVerification {
                     "**/com/ureca/snac/money/**",
                     "**/com/ureca/snac/outbox/**",
                     "**/com/ureca/snac/payment/**",
-                    "**/com/ureca/snac/wallet/listener/**"
+                    "**/com/ureca/snac/wallet/**"
             ]
             excludes = [
                     "**/dto/**",

--- a/src/main/java/com/ureca/snac/dev/service/DevToolServiceImpl.java
+++ b/src/main/java/com/ureca/snac/dev/service/DevToolServiceImpl.java
@@ -19,6 +19,7 @@ import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.exception.PaymentNotFoundException;
 import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.payment.service.PaymentService;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
 import com.ureca.snac.wallet.service.WalletService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -95,8 +96,7 @@ public class DevToolServiceImpl implements DevToolService {
         Member member = memberRepository.findByEmail(request.email())
                 .orElseThrow(MemberNotFoundException::new);
 
-        walletService.depositPoint(member.getId(), request.amount());
-        long balanceAfter = walletService.getPointBalance(member.getId());
+        long balanceAfter = walletService.depositPoint(member.getId(), request.amount());
 
         // 개발용 포인트 지급은 커스텀 사유를 허용하므로 직접 저장
         saveDevPointGrant(member, request.amount(), balanceAfter, request.reason());
@@ -134,13 +134,14 @@ public class DevToolServiceImpl implements DevToolService {
                         request.moneyAmountToUse(), request.pointAmountToUse()
                 );
 
-        walletService.withdrawComposite(ctx.buyer().getId(), request.moneyAmountToUse(), request.pointAmountToUse());
+        walletService.moveCompositeToEscrow(ctx.buyer().getId(), request.moneyAmountToUse(), request.pointAmountToUse());
+        CompositeBalanceResult buyerResult = walletService.deductCompositeEscrow(ctx.buyer().getId(), request.moneyAmountToUse(), request.pointAmountToUse());
 
         long sellerMoneyBalanceAfter = (request.moneyAmountToUse() > 0) ?
                 walletService.depositMoney(ctx.seller().getId(), request.moneyAmountToUse()) :
                 walletService.getMoneyBalance(ctx.seller().getId());
 
-        recordTradeAssets(ctx, request.moneyAmountToUse(), request.pointAmountToUse(), sellerMoneyBalanceAfter);
+        recordTradeAssets(ctx, request.moneyAmountToUse(), request.pointAmountToUse(), sellerMoneyBalanceAfter, buyerResult);
 
         log.info("[개발용 거래 완료] 완료. 생성된 Trade ID : {}", ctx.trade().getId());
 
@@ -148,22 +149,19 @@ public class DevToolServiceImpl implements DevToolService {
     }
 
     private void recordTradeAssets(DevDataSupport.TradeCompletionContext ctx, long moneyUsed,
-                                   long pointUsed, long sellerMoneyBalance) {
+                                   long pointUsed, long sellerMoneyBalance, CompositeBalanceResult buyerResult) {
 
         String title = String.format("%s %dGB", ctx.card().getCarrier().name(), ctx.card().getDataAmount());
 
-        long buyerMoneyBalance = walletService.getMoneyBalance(ctx.buyer().getId());
-        long buyerPointBalance = walletService.getPointBalance(ctx.buyer().getId());
-
         if (moneyUsed > 0) {
             assetRecorder.recordTradeBuy(ctx.buyer().getId(), ctx.trade().getId(),
-                    title + " 머니 사용", AssetType.MONEY, moneyUsed, buyerMoneyBalance);
+                    title + " 머니 사용", AssetType.MONEY, moneyUsed, buyerResult.moneyBalance());
             assetRecorder.recordTradeSell(ctx.seller().getId(), ctx.trade().getId(),
                     title + " 판매 대금", moneyUsed, sellerMoneyBalance);
         }
         if (pointUsed > 0) {
             assetRecorder.recordTradeBuy(ctx.buyer().getId(), ctx.trade().getId(),
-                    title + " 포인트 사용", AssetType.POINT, pointUsed, buyerPointBalance);
+                    title + " 포인트 사용", AssetType.POINT, pointUsed, buyerResult.pointBalance());
         }
     }
 

--- a/src/main/java/com/ureca/snac/wallet/entity/Wallet.java
+++ b/src/main/java/com/ureca/snac/wallet/entity/Wallet.java
@@ -79,10 +79,6 @@ public class Wallet extends BaseTimeEntity {
         this.point.deposit(amount);
     }
 
-    public void withdrawPoint(long amount) {
-        this.point.withdraw(amount);
-    }
-
     public void movePointToEscrow(long amount) {
         this.point.moveToEscrow(amount);
     }
@@ -103,19 +99,11 @@ public class Wallet extends BaseTimeEntity {
         return this.money.getEscrow();
     }
 
-    public Long getTotalMoney() {
-        return this.money.getTotal();
-    }
-
     public Long getPointBalance() {
         return this.point.getBalance();
     }
 
     public Long getPointEscrow() {
         return this.point.getEscrow();
-    }
-
-    public Long getTotalPoint() {
-        return this.point.getTotal();
     }
 }

--- a/src/main/java/com/ureca/snac/wallet/service/WalletService.java
+++ b/src/main/java/com/ureca/snac/wallet/service/WalletService.java
@@ -14,28 +14,10 @@ public interface WalletService {
 
     Long withdrawMoney(Long memberId, long amount);
 
-    // 머니 에스크로
-    long moveMoneyToEscrow(Long memberId, long amount);
-
-    long releaseMoneyEscrow(Long memberId, long amount);
-
-    long deductMoneyEscrow(Long memberId, long amount);
-
-    // 포인트 입출금
+    // 포인트 입금
     Long depositPoint(Long memberId, long amount);
 
-    Long withdrawPoint(Long memberId, long amount);
-
-    // 포인트 에스크로
-    long movePointToEscrow(Long memberId, long amount);
-
-    long releasePointEscrow(Long memberId, long amount);
-
-    long deductPointEscrow(Long memberId, long amount);
-
-    // 복합 결제
-    CompositeBalanceResult withdrawComposite(Long memberId, long moneyAmount, long pointAmount);
-
+    // 복합 에스크로
     CompositeBalanceResult moveCompositeToEscrow(Long memberId, long moneyAmount, long pointAmount);
 
     CompositeBalanceResult releaseCompositeEscrow(Long memberId, long moneyAmount, long pointAmount);
@@ -44,12 +26,6 @@ public interface WalletService {
 
     // 조회
     long getMoneyBalance(Long memberId);
-
-    long getMoneyEscrow(Long memberId);
-
-    long getPointBalance(Long memberId);
-
-    long getPointEscrow(Long memberId);
 
     // 특정 회원의 지갑 요약 정보(머니, 포인트 잔액) 조회
     WalletSummaryResponse getWalletSummary(String email);

--- a/src/main/java/com/ureca/snac/wallet/service/WalletServiceImpl.java
+++ b/src/main/java/com/ureca/snac/wallet/service/WalletServiceImpl.java
@@ -1,13 +1,13 @@
 package com.ureca.snac.wallet.service;
 
 import com.ureca.snac.member.entity.Member;
-import com.ureca.snac.wallet.repository.WalletRepository;
 import com.ureca.snac.wallet.dto.CompositeBalanceResult;
 import com.ureca.snac.wallet.dto.WalletSummaryResponse;
 import com.ureca.snac.wallet.entity.Wallet;
 import com.ureca.snac.wallet.event.WalletCreatedEvent;
-import com.ureca.snac.wallet.exception.InsufficientBalanceException;
+import com.ureca.snac.wallet.exception.InvalidAmountException;
 import com.ureca.snac.wallet.exception.WalletNotFoundException;
+import com.ureca.snac.wallet.repository.WalletRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
@@ -96,50 +96,6 @@ public class WalletServiceImpl implements WalletService {
 
     @Override
     @Transactional
-    public long moveMoneyToEscrow(Long memberId, long amount) {
-        log.info("[머니 에스크로 이동] 시작. 회원 ID: {}, 금액: {}", memberId, amount);
-
-        Wallet wallet = findWalletWithLock(memberId);
-        wallet.moveMoneyToEscrow(amount);
-
-        long finalBalance = wallet.getMoneyBalance();
-        log.info("[머니 에스크로 이동] 완료. 회원 ID: {}, 잔액: {}, 에스크로: {}",
-                memberId, finalBalance, wallet.getMoneyEscrow());
-
-        return finalBalance;
-    }
-
-    @Override
-    @Transactional
-    public long releaseMoneyEscrow(Long memberId, long amount) {
-        log.info("[머니 에스크로 복원] 시작. 회원 ID: {}, 금액: {}", memberId, amount);
-
-        Wallet wallet = findWalletWithLock(memberId);
-        wallet.releaseMoneyEscrow(amount);
-
-        long finalBalance = wallet.getMoneyBalance();
-        log.info("[머니 에스크로 복원] 완료. 회원 ID: {}, 잔액: {}, 에스크로: {}",
-                memberId, finalBalance, wallet.getMoneyEscrow());
-
-        return finalBalance;
-    }
-
-    @Override
-    @Transactional
-    public long deductMoneyEscrow(Long memberId, long amount) {
-        log.info("[머니 에스크로 차감] 시작. 회원 ID: {}, 금액: {}", memberId, amount);
-
-        Wallet wallet = findWalletWithLock(memberId);
-        wallet.deductMoneyEscrow(amount);
-
-        long finalEscrow = wallet.getMoneyEscrow();
-        log.info("[머니 에스크로 차감] 완료. 회원 ID: {}, 에스크로: {}", memberId, finalEscrow);
-
-        return wallet.getMoneyBalance();
-    }
-
-    @Override
-    @Transactional
     public Long depositPoint(Long memberId, long amount) {
         log.info("[포인트 적립] 시작. 회원 ID: {}, 적립액: {}", memberId, amount);
 
@@ -158,96 +114,8 @@ public class WalletServiceImpl implements WalletService {
 
     @Override
     @Transactional
-    public Long withdrawPoint(Long memberId, long amount) {
-        log.info("[포인트 사용] 시작. 회원 ID: {}, 사용액: {}", memberId, amount);
-
-        Wallet wallet = findWalletWithLock(memberId);
-        wallet.withdrawPoint(amount);
-
-        long finalBalance = wallet.getPointBalance();
-        log.info("[포인트 사용] 완료. 회원 ID: {}, 최종 잔액: {}", memberId, finalBalance);
-        Counter.builder("wallet_operation_total")
-                .tag("type", "withdraw_point")
-                .register(meterRegistry).increment();
-
-        return finalBalance;
-    }
-
-    @Override
-    @Transactional
-    public long movePointToEscrow(Long memberId, long amount) {
-        log.info("[포인트 에스크로 이동] 시작. 회원 ID: {}, 금액: {}", memberId, amount);
-
-        Wallet wallet = findWalletWithLock(memberId);
-        wallet.movePointToEscrow(amount);
-
-        long finalBalance = wallet.getPointBalance();
-        log.info("[포인트 에스크로 이동] 완료. 회원 ID: {}, 잔액: {}, 에스크로: {}",
-                memberId, finalBalance, wallet.getPointEscrow());
-
-        return finalBalance;
-    }
-
-    @Override
-    @Transactional
-    public long releasePointEscrow(Long memberId, long amount) {
-        log.info("[포인트 에스크로 복원] 시작. 회원 ID: {}, 금액: {}", memberId, amount);
-
-        Wallet wallet = findWalletWithLock(memberId);
-        wallet.releasePointEscrow(amount);
-
-        long finalBalance = wallet.getPointBalance();
-        log.info("[포인트 에스크로 복원] 완료. 회원 ID: {}, 잔액: {}, 에스크로: {}",
-                memberId, finalBalance, wallet.getPointEscrow());
-
-        return finalBalance;
-    }
-
-    @Override
-    @Transactional
-    public long deductPointEscrow(Long memberId, long amount) {
-        log.info("[포인트 에스크로 차감] 시작. 회원 ID: {}, 금액: {}", memberId, amount);
-
-        Wallet wallet = findWalletWithLock(memberId);
-        wallet.deductPointEscrow(amount);
-
-        long finalEscrow = wallet.getPointEscrow();
-        log.info("[포인트 에스크로 차감] 완료. 회원 ID: {}, 에스크로: {}", memberId, finalEscrow);
-
-        return wallet.getPointBalance();
-    }
-
-    @Override
-    @Transactional
-    public CompositeBalanceResult withdrawComposite(Long memberId, long moneyAmount, long pointAmount) {
-        if (moneyAmount <= 0 && pointAmount <= 0) {
-            throw new IllegalArgumentException("출금 금액은 0보다 커야 합니다.");
-        }
-
-        log.info("[복합 출금] 시작. 회원 ID: {}, 머니: {}, 포인트: {}", memberId, moneyAmount, pointAmount);
-
-        Wallet wallet = findWalletWithLock(memberId);
-
-        if (moneyAmount > 0) {
-            wallet.withdrawMoney(moneyAmount);
-        }
-        if (pointAmount > 0) {
-            wallet.withdrawPoint(pointAmount);
-        }
-
-        CompositeBalanceResult result = CompositeBalanceResult.from(wallet);
-        log.info("[복합 출금] 완료. 회원 ID: {}, 머니 잔액: {}, 포인트 잔액: {}",
-                memberId, result.moneyBalance(), result.pointBalance());
-
-        return result;
-    }
-
-    @Override
-    @Transactional
     public CompositeBalanceResult moveCompositeToEscrow(Long memberId, long moneyAmount, long pointAmount) {
-        if (moneyAmount <= 0 && pointAmount <= 0) {
-            throw new InsufficientBalanceException();
-        }
+        validateCompositeAmounts(moneyAmount, pointAmount);
 
         log.info("[복합 에스크로 이동] 시작. 회원 ID: {}, 머니: {}, 포인트: {}", memberId, moneyAmount, pointAmount);
 
@@ -270,9 +138,7 @@ public class WalletServiceImpl implements WalletService {
     @Override
     @Transactional
     public CompositeBalanceResult releaseCompositeEscrow(Long memberId, long moneyAmount, long pointAmount) {
-        if (moneyAmount <= 0 && pointAmount <= 0) {
-            throw new InsufficientBalanceException();
-        }
+        validateCompositeAmounts(moneyAmount, pointAmount);
 
         log.info("[복합 에스크로 복원] 시작. 회원 ID: {}, 머니: {}, 포인트: {}", memberId, moneyAmount, pointAmount);
 
@@ -295,9 +161,7 @@ public class WalletServiceImpl implements WalletService {
     @Override
     @Transactional
     public CompositeBalanceResult deductCompositeEscrow(Long memberId, long moneyAmount, long pointAmount) {
-        if (moneyAmount <= 0 && pointAmount <= 0) {
-            throw new InsufficientBalanceException();
-        }
+        validateCompositeAmounts(moneyAmount, pointAmount);
 
         log.info("[복합 에스크로 차감] 시작. 회원 ID : {}, 머니 : {}, 포인트 : {}", memberId, moneyAmount, pointAmount);
 
@@ -324,25 +188,6 @@ public class WalletServiceImpl implements WalletService {
     }
 
     @Override
-    public long getMoneyEscrow(Long memberId) {
-        Wallet wallet = findWallet(memberId);
-        return wallet.getMoneyEscrow();
-    }
-
-    @Override
-    public long getPointBalance(Long memberId) {
-        Wallet wallet = findWallet(memberId);
-        return wallet.getPointBalance();
-    }
-
-    @Override
-    public long getPointEscrow(Long memberId) {
-        Wallet wallet = findWallet(memberId);
-        return wallet.getPointEscrow();
-    }
-
-
-    @Override
     public WalletSummaryResponse getWalletSummary(String email) {
         log.info("[지갑 요약 조회] 시작. 이메일 : {}", email);
 
@@ -356,6 +201,12 @@ public class WalletServiceImpl implements WalletService {
         log.info("[지갑 요약 조회] 완료. 이메일 : {}", email);
 
         return response;
+    }
+
+    private void validateCompositeAmounts(long moneyAmount, long pointAmount) {
+        if (moneyAmount < 0 || pointAmount < 0 || (moneyAmount == 0 && pointAmount == 0)) {
+            throw new InvalidAmountException();
+        }
     }
 
     private Wallet findWallet(Long memberId) {


### PR DESCRIPTION
## 변경 사항 요약

구매 시 잔액 즉시 차감 구조를 에스크로 홀드 모델로 전환하는 Wallet 서비스 계층 구현

Closes #48

---

## 주요 변경 사항

### 1. WalletService 인터페이스 정리

**WalletService**

- 개별 에스크로 메서드(머니·포인트 각각) 제거
- 복합 에스크로 3종(`moveCompositeToEscrow` / `releaseCompositeEscrow` / `deductCompositeEscrow`)만 노출
- 불필요한 조회 메서드(`getMoneyEscrow`, `getPointBalance`, `getPointEscrow`) 제거

### 2. WalletServiceImpl 구현

**WalletServiceImpl**

- `withdrawComposite` 제거, 복합 에스크로 메서드로 대체
- `moveCompositeToEscrow`: balance → escrow 이동
- `releaseCompositeEscrow`: escrow → balance 복원 (취소·환불)
- `deductCompositeEscrow`: escrow 소멸 (확정 정산)
- 검증 로직 `validateCompositeAmounts()` private helper로 추출

### 3. 검증 조건 버그 수정

**WalletServiceImpl** (3개 복합 메서드 공통)

- `moneyAmount <= 0 && pointAmount <= 0` → `moneyAmount < 0 || pointAmount < 0 || (moneyAmount == 0 && pointAmount == 0)`
- 기존: 머니 음수 + 포인트 양수 조합이 검증 통과되는 버그
- 예외 타입 `InsufficientBalanceException` → `InvalidAmountException`

---

## 동작 흐름

### 구매 흐름

```
구매 요청 → moveCompositeToEscrow → balance 감소, escrow 증가
확정 시   → deductCompositeEscrow → escrow 소멸 → 판매자 정산
취소 시   → releaseCompositeEscrow → escrow 감소, balance 복원
```

---

## 기술적 의사결정

### 왜 개별 메서드를 제거하고 복합 메서드만 남기는가?

**문제**
- 머니/포인트 에스크로를 각각 호출하면 호출 순서나 조합을 서비스 레이어에서 관리해야 함
- 머니 이동 성공 후 포인트 이동 실패 시 부분 상태 발생 가능

**해결**
- 복합 메서드 하나에서 머니·포인트를 단일 트랜잭션 내에 처리

**비교**
- 개별 메서드 유지: 유연성은 있으나 호출부 실수로 인한 부분 처리 위험