### PR TITLE
[feat] 거래 서비스 에스크로 흐름 연결

### DIFF
--- a/src/main/java/com/ureca/snac/trade/entity/Trade.java
+++ b/src/main/java/com/ureca/snac/trade/entity/Trade.java
@@ -262,7 +262,7 @@ public class Trade extends BaseTimeEntity {
     }
 
     public long getMoneyAmount() {
-        return priceGb - getPointOrZero();
+        return (priceGb != null ? priceGb : 0) - getPointOrZero();
     }
 
     /**

--- a/src/main/java/com/ureca/snac/trade/entity/Trade.java
+++ b/src/main/java/com/ureca/snac/trade/entity/Trade.java
@@ -257,6 +257,14 @@ public class Trade extends BaseTimeEntity {
         this.seller = seller;
     }
 
+    public int getPointOrZero() {
+        return point != null ? point : 0;
+    }
+
+    public long getMoneyAmount() {
+        return priceGb - getPointOrZero();
+    }
+
     /**
      * 결제 금액(머니 + 포인트)이 주문 금액(priceGb)과 일치하는지 검증.
      * 일치하지 않으면 TradePaymentMismatchException을 던진다.

--- a/src/main/java/com/ureca/snac/trade/scheduler/TradeAutoItemProcessor.java
+++ b/src/main/java/com/ureca/snac/trade/scheduler/TradeAutoItemProcessor.java
@@ -11,6 +11,7 @@ import com.ureca.snac.trade.entity.Trade;
 import com.ureca.snac.trade.entity.TradeStatus;
 import com.ureca.snac.trade.service.TradeAlertService;
 import com.ureca.snac.trade.service.interfaces.PenaltyService;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
 import com.ureca.snac.wallet.service.WalletService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,22 +51,24 @@ public class TradeAutoItemProcessor {
         Card card = findLockedCard(trade.getCardId());
         Member buyer = trade.getBuyer();
 
-        long moneyToRefund = trade.getPriceGb() - trade.getPoint();
+        int point = trade.getPointOrZero();
+        long moneyToRefund = trade.getMoneyAmount();
+
+        CompositeBalanceResult result =
+                walletService.releaseCompositeEscrow(buyer.getId(), moneyToRefund, point);
+
         if (moneyToRefund > 0) {
-            long moneyFinalBalance = walletService.depositMoney(buyer.getId(), moneyToRefund);
             String title = String.format("%s %dGB 자동 환불",
                     card.getCarrier().name(), card.getDataAmount());
             assetRecorder.recordTradeCancelRefund(
-                    buyer.getId(), trade.getId(), title, AssetType.MONEY, moneyToRefund, moneyFinalBalance);
+                    buyer.getId(), trade.getId(), title, AssetType.MONEY, moneyToRefund, result.moneyBalance());
         }
 
-        long pointToRefund = trade.getPoint();
-        if (pointToRefund > 0) {
-            long pointFinalBalance = walletService.depositPoint(buyer.getId(), pointToRefund);
+        if (point > 0) {
             String title = String.format("%s %dGB 자동 포인트 환불",
                     card.getCarrier().name(), card.getDataAmount());
             assetRecorder.recordTradeCancelRefund(
-                    buyer.getId(), trade.getId(), title, AssetType.POINT, pointToRefund, pointFinalBalance);
+                    buyer.getId(), trade.getId(), title, AssetType.POINT, (long) point, result.pointBalance());
         }
 
         trade.cancel(trade.getBuyer());
@@ -101,8 +104,13 @@ public class TradeAutoItemProcessor {
     @Transactional
     public void processPayout(Trade trade) {
         Card card = findLockedCard(trade.getCardId());
+        Member buyer = trade.getBuyer();
         Member seller = trade.getSeller();
 
+        // 1. 구매자 에스크로 차감 (escrow → 소멸)
+        walletService.deductCompositeEscrow(buyer.getId(), trade.getMoneyAmount(), trade.getPointOrZero());
+
+        // 2. 판매자에게 총액 입금
         long amountToDeposit = trade.getPriceGb();
         long finalBalance = walletService.depositMoney(seller.getId(), amountToDeposit);
 

--- a/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/DisputeAdminServiceImpl.java
@@ -6,10 +6,10 @@ import com.ureca.snac.board.repository.CardRepository;
 import com.ureca.snac.common.BaseCode;
 import com.ureca.snac.common.exception.BusinessException;
 import com.ureca.snac.common.s3.S3Uploader;
-import com.ureca.snac.member.entity.Member;
-import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.member.Role;
+import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.member.exception.MemberNotFoundException;
+import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.trade.dto.DisputeSearchCond;
 import com.ureca.snac.trade.dto.dispute.DisputeAnswerRequest;
 import com.ureca.snac.trade.dto.dispute.DisputeDetailResponse;
@@ -23,9 +23,9 @@ import com.ureca.snac.trade.repository.DisputeRepository;
 import com.ureca.snac.trade.service.interfaces.DisputeAdminService;
 import com.ureca.snac.trade.service.interfaces.PenaltyService;
 import com.ureca.snac.trade.service.interfaces.TradeCancelService;
-import com.ureca.snac.wallet.repository.WalletRepository;
 import com.ureca.snac.wallet.entity.Wallet;
 import com.ureca.snac.wallet.exception.WalletNotFoundException;
+import com.ureca.snac.wallet.repository.WalletRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -149,7 +149,7 @@ public class DisputeAdminServiceImpl implements DisputeAdminService {
         Card card = cardRepository.findById(trade.getCardId()).orElseThrow(CardNotFoundException::new);
         Member buyer = trade.getBuyer();
 
-        tradeCancelService.refundToBuyerAndPublishEvent(trade, card, buyer);
+        tradeCancelService.refundBuyerEscrow(trade, card, buyer);
 //        // 환불 계산
 //        int priceGb = trade.getPriceGb() == null ? 0 : trade.getPriceGb();
 //        int pointUnit = trade.getPoint()   == null ? 0 : trade.getPoint();

--- a/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeCancelServiceImpl.java
@@ -8,8 +8,8 @@ import com.ureca.snac.board.entity.constants.SellStatus;
 import com.ureca.snac.board.exception.CardNotFoundException;
 import com.ureca.snac.board.repository.CardRepository;
 import com.ureca.snac.member.entity.Member;
-import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.member.exception.MemberNotFoundException;
+import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.trade.controller.request.CancelBuyRequest;
 import com.ureca.snac.trade.dto.TradeDto;
 import com.ureca.snac.trade.entity.*;
@@ -18,6 +18,7 @@ import com.ureca.snac.trade.repository.TradeCancelRepository;
 import com.ureca.snac.trade.repository.TradeRepository;
 import com.ureca.snac.trade.service.interfaces.PenaltyService;
 import com.ureca.snac.trade.service.interfaces.TradeCancelService;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
 import com.ureca.snac.wallet.service.WalletService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -98,11 +99,11 @@ public class TradeCancelServiceImpl implements TradeCancelService {
 
             // 카드 상태 처리
             // 지금 판매자가 취소 요청 상태인데 판매글이면 삭제 처리 / 구매글이면 다시 구매중으로
-            if(card.getCardCategory() == CardCategory.SELL){
+            if (card.getCardCategory() == CardCategory.SELL) {
 //                card.changeSellStatus(SellStatus.CANCEL);
                 // 카드 삭제 처리
                 cardRepo.deleteById(card.getId());
-            } else if (card.getCardCategory() == CardCategory.BUY){
+            } else if (card.getCardCategory() == CardCategory.BUY) {
                 card.changeSellStatus(SellStatus.SELLING);
             }
 
@@ -110,9 +111,9 @@ public class TradeCancelServiceImpl implements TradeCancelService {
             trade.cancel(requester);
             trade.changeCancelReason(reason);
 
-            refundToBuyerAndPublishEvent(trade, card, buyer);
+            refundBuyerEscrow(trade, card, buyer);
 //            일단 프라비잇으로 환불 로직이랑 이벤트 호출하는거 헬퍼 메소드로 뺏다. 중복 로직이라서 이후의 리팩토링은 자유
-//            refundToBuyerAndPublishEvent 활용 trade랑 card 있어야함 -> 제목 필요
+//            refundBuyerEscrow 활용 trade랑 card 있어야함 -> 제목 필요
 //            나는 wallet 의존관계 주입받아서 쓸꺼 굳이 엔티티 계층 접근필요 X
 
 //            Wallet buyerWallet = tradeSupport.findLockedWallet(trade.getBuyer().getId());
@@ -126,7 +127,7 @@ public class TradeCancelServiceImpl implements TradeCancelService {
 
             // 알림 추가
 
-        } else if (trade.getSeller() == null){
+        } else if (trade.getSeller() == null) {
             // 취소 엔티티 저장: ACCEPTED & resolvedAt
             TradeCancel cancel = TradeCancel.builder()
                     .trade(trade)
@@ -145,10 +146,9 @@ public class TradeCancelServiceImpl implements TradeCancelService {
             // 거래 취소 및 환불 및 이유 입력
             trade.cancel(requester);
             trade.changeCancelReason(reason);
-            refundToBuyerAndPublishEvent(trade, card, buyer);
+            refundBuyerEscrow(trade, card, buyer);
             // 패널티 x
-        }
-        else {
+        } else {
             // 구매자 : 한 번이라도 요청했으면 무조건 중복 차단
             if (prevCancelOpt.isPresent()) {
                 throw new TradeAlreadyCancelRequestedException();
@@ -195,11 +195,11 @@ public class TradeCancelServiceImpl implements TradeCancelService {
 
         // 카드 상태 처리
         // 지금 구매자가 취소 요청 상태인데 구매글이면 삭제 처리 / 판매글이면 다시 판매중으로
-        if(card.getCardCategory() == CardCategory.BUY){
+        if (card.getCardCategory() == CardCategory.BUY) {
 //            card.changeSellStatus(SellStatus.CANCEL);
             // 카드 삭제 처리
             cardRepo.deleteById(card.getId());
-        } else if (card.getCardCategory() == CardCategory.SELL){
+        } else if (card.getCardCategory() == CardCategory.SELL) {
             card.changeSellStatus(SellStatus.SELLING);
         }
 
@@ -209,7 +209,7 @@ public class TradeCancelServiceImpl implements TradeCancelService {
         trade.changeCancelReason(cancel.getReason());//취소 사유
 
 //        위와 마찬가지 이유
-        refundToBuyerAndPublishEvent(trade, card, buyer);
+        refundBuyerEscrow(trade, card, buyer);
 //        // 환불 로직 (TradeProgressService.cancelTrade에 있던 부분 재활용)
 //        long refundMoney = (long) (trade.getPriceGb() - trade.getPoint()) * trade.getDataAmount();
 //        if (refundMoney > 0) wallet.depositMoney(refundMoney);
@@ -220,26 +220,25 @@ public class TradeCancelServiceImpl implements TradeCancelService {
         penaltyService.givePenalty(cancel.getRequester().getEmail(), PenaltyReason.BUYER_FAULT);
     }
 
-    public void refundToBuyerAndPublishEvent(Trade trade, Card card, Member buyer) {
-        long moneyToRefund = trade.getPriceGb() - trade.getPoint();
+    public void refundBuyerEscrow(Trade trade, Card card, Member buyer) {
+        long moneyToRefund = trade.getMoneyAmount();
+        int point = trade.getPointOrZero();
+
+        CompositeBalanceResult result =
+                walletService.releaseCompositeEscrow(buyer.getId(), moneyToRefund, point);
 
         if (moneyToRefund > 0) {
-            long moneyFinalBalance = walletService.depositMoney(buyer.getId(), moneyToRefund);
-
             String title = String.format("%s %dGB 거래 취소",
                     card.getCarrier().name(), card.getDataAmount());
             assetRecorder.recordTradeCancelRefund(
-                    buyer.getId(), trade.getId(), title, AssetType.MONEY, moneyToRefund, moneyFinalBalance);
+                    buyer.getId(), trade.getId(), title, AssetType.MONEY, moneyToRefund, result.moneyBalance());
         }
 
-        long pointToRefund = trade.getPoint();
-        if (pointToRefund > 0) {
-            long pointFinalBalance = walletService.depositPoint(buyer.getId(), pointToRefund);
-
+        if (point > 0) {
             String title = String.format("%s %dGB 포인트 환불",
                     card.getCarrier().name(), card.getDataAmount());
             assetRecorder.recordTradeCancelRefund(
-                    buyer.getId(), trade.getId(), title, AssetType.POINT, pointToRefund, pointFinalBalance);
+                    buyer.getId(), trade.getId(), title, AssetType.POINT, (long) point, result.pointBalance());
         }
     }
 
@@ -328,7 +327,7 @@ public class TradeCancelServiceImpl implements TradeCancelService {
         Card card = findLockedCard(trade.getCardId());
 
         if (trade.getStatus() == TradeStatus.PAYMENT_CONFIRMED) {
-            refundToBuyerAndPublishEvent(trade, card, trade.getBuyer());
+            refundBuyerEscrow(trade, card, trade.getBuyer());
         }
 
         // 거래 수락전이라면 카드를 삭제하면 안됨

--- a/src/main/java/com/ureca/snac/trade/service/TradeInitiationServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeInitiationServiceImpl.java
@@ -17,9 +17,7 @@ import com.ureca.snac.trade.entity.Trade;
 import com.ureca.snac.trade.exception.TradeNotFoundException;
 import com.ureca.snac.trade.repository.TradeRepository;
 import com.ureca.snac.trade.service.interfaces.TradeInitiationService;
-import com.ureca.snac.wallet.entity.Wallet;
-import com.ureca.snac.wallet.exception.WalletNotFoundException;
-import com.ureca.snac.wallet.repository.WalletRepository;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
 import com.ureca.snac.wallet.service.WalletService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,7 +40,6 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
 
     private final TradeRepository tradeRepository;
     private final MemberRepository memberRepository;
-    private final WalletRepository walletRepository;
     private final CardRepository cardRepository;
 
     private final WalletService walletService;
@@ -73,11 +70,9 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
     )
     @Transactional
     public Long payRealTimeTrade(CreateRealTimeTradePaymentRequest createRealTimeTradePaymentRequest, String username) {
-        // 1. 거래 조회 (락 걸어서)
         Member member = findMember(username);
         Trade trade = findLockedTrade(createRealTimeTradePaymentRequest.getTradeId());
         Card card = findCard(trade.getCardId());
-        Wallet wallet = findLockedWallet(member.getId());
 
         long moneyToUse = createRealTimeTradePaymentRequest.getMoney();
         long pointToUse = createRealTimeTradePaymentRequest.getPoint();
@@ -87,34 +82,25 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
         trade.ensureBuyer(member); // 구매자만 결제할 수 있어야 함
         trade.ensurePaymentMatches(moneyToUse, pointToUse);
 
-        // 1.결제 먼저
-        long moneyBalanceAfter = -1L;
-
-        // 금액 및 포인트 차감
-        if (moneyToUse > 0) {
-            moneyBalanceAfter = walletService.withdrawMoney(member.getId(), moneyToUse);
-        }
-
-        long pointBalanceAfter = -1L;
-        if (pointToUse > 0) {
-            pointBalanceAfter = walletService.withdrawPoint(member.getId(), pointToUse);
-        }
+        // 1. 결제 먼저 (에스크로 보관: balance → escrow)
+        CompositeBalanceResult escrowResult =
+                walletService.moveCompositeToEscrow(member.getId(), moneyToUse, pointToUse);
 
         trade.markPaymentConfirmed(createRealTimeTradePaymentRequest.getPoint()); // Accepted -> Confirmed
 
-        // 3 기록
+        // 2. 기록
         if (moneyToUse > 0) {
             String title = String.format("%s %dGB 머니 사용",
                     card.getCarrier().name(), card.getDataAmount());
             assetRecorder.recordTradeBuy(
-                    member.getId(), trade.getId(), title, AssetType.MONEY, moneyToUse, moneyBalanceAfter);
+                    member.getId(), trade.getId(), title, AssetType.MONEY, moneyToUse, escrowResult.moneyBalance());
         }
 
         if (pointToUse > 0) {
             String title = String.format("%s %dGB 포인트 사용",
                     card.getCarrier().name(), card.getDataAmount());
             assetRecorder.recordTradeBuy(
-                    member.getId(), trade.getId(), title, AssetType.POINT, pointToUse, pointBalanceAfter);
+                    member.getId(), trade.getId(), title, AssetType.POINT, pointToUse, escrowResult.pointBalance());
         }
 
         return trade.getId();
@@ -241,32 +227,25 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
         card.ensureCreatableBy(member, requiredStatus); // 거래 생성 소유자 조건 확인: 판매글 -> 타인, 구매글 -> 본인
         card.ensurePaymentMatches(moneyToUse, pointToUse); // 결제 금액 검증 (금액 + 포인트 == 카드 가격)
 
-        long moneyBalanceAfter = -1L;
-        if (moneyToUse > 0) {
-            moneyBalanceAfter = walletService.withdrawMoney(member.getId(), moneyToUse);
-        }
+        // 1. 결제 (에스크로 보관: balance → escrow)
+        CompositeBalanceResult escrowResult =
+                walletService.moveCompositeToEscrow(member.getId(), moneyToUse, pointToUse);
 
-        long pointBalanceAfter = -1L;
-        if (pointToUse > 0) {
-            pointBalanceAfter = walletService.withdrawPoint(member.getId(), pointToUse);
-        }
-
-        // 2, 거래 생성
-        // 거래 엔티티 생성 및 저장
+        // 2. 거래 생성 및 저장
         Trade trade = Trade.buildTrade((int) pointToUse, member, member.getPhone(), card, requiredStatus);
         tradeRepository.save(trade);
 
-        // 3 기록
+        // 3. 기록
         if (moneyToUse > 0) {
             String title = String.format("%s %dGB 머니 사용", trade.getCarrier().name(), trade.getDataAmount());
             assetRecorder.recordTradeBuy(
-                    member.getId(), trade.getId(), title, AssetType.MONEY, moneyToUse, moneyBalanceAfter);
+                    member.getId(), trade.getId(), title, AssetType.MONEY, moneyToUse, escrowResult.moneyBalance());
         }
 
         if (pointToUse > 0) {
             String title = String.format("%s %dGB 포인트 사용", trade.getCarrier().name(), trade.getDataAmount());
             assetRecorder.recordTradeBuy(
-                    member.getId(), trade.getId(), title, AssetType.POINT, pointToUse, pointBalanceAfter);
+                    member.getId(), trade.getId(), title, AssetType.POINT, pointToUse, escrowResult.pointBalance());
         }
 
         // 카드 상태 변경 (판매글이면 TRADING, 구매글이면 SELLING)
@@ -281,10 +260,6 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
 
     private Member findMember(String email) {
         return memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
-    }
-
-    private Wallet findLockedWallet(Long memberId) {
-        return walletRepository.findByMemberIdWithLock(memberId).orElseThrow(WalletNotFoundException::new);
     }
 
     private Card findLockedCard(Long cardId) {

--- a/src/main/java/com/ureca/snac/trade/service/TradeInitiationServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeInitiationServiceImpl.java
@@ -86,7 +86,7 @@ public class TradeInitiationServiceImpl implements TradeInitiationService {
         CompositeBalanceResult escrowResult =
                 walletService.moveCompositeToEscrow(member.getId(), moneyToUse, pointToUse);
 
-        trade.markPaymentConfirmed(createRealTimeTradePaymentRequest.getPoint()); // Accepted -> Confirmed
+        trade.markPaymentConfirmed((int) createRealTimeTradePaymentRequest.getPoint()); // Accepted -> Confirmed
 
         // 2. 기록
         if (moneyToUse > 0) {

--- a/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
+++ b/src/main/java/com/ureca/snac/trade/service/TradeProgressServiceImpl.java
@@ -73,13 +73,10 @@ public class TradeProgressServiceImpl implements TradeProgressService {
 
         trade.confirm(buyer); // 거래 상태를 확정으로 변경
 
-        if (hasCard) {
-            Card card = findLockedCard(trade.getCardId());
-            card.markSoldOut(); // 카드 상태를 판매 완료로 변경
-        } else {
-            cardRepository.deleteById(trade.getCardId()); // 실시간 매칭에서는 거래가 끝난 경우 카드는 필요 없으므로 삭제
-        }
+        // 1. 구매자 에스크로 차감 (escrow → 소멸) — 자금 이동을 카드 상태 변경보다 우선
+        walletService.deductCompositeEscrow(buyer.getId(), trade.getMoneyAmount(), trade.getPointOrZero());
 
+        // 2. 판매자에게 총액 입금 (머니로 지급, 포인트 사용분도 플랫폼이 환산하여 머니로 지급)
         long amountToDeposit = trade.getPriceGb();
         long finalMoneyBalance = walletService.depositMoney(seller.getId(), amountToDeposit);
 
@@ -94,6 +91,14 @@ public class TradeProgressServiceImpl implements TradeProgressService {
 
         assetRecorder.recordTradeCompletionBonus(
                 seller.getId(), trade.getId(), amount, finalPointBalance);
+
+        // 3. 카드 상태 변경 — 자금 이동 완료 후 처리
+        if (hasCard) {
+            Card card = findLockedCard(trade.getCardId());
+            card.markSoldOut();
+        } else {
+            cardRepository.deleteById(trade.getCardId());
+        }
 
         memberService.addRatingScore(buyer.getId(), RATING_SCORE_BONUS);
         memberService.addRatingScore(seller.getId(), RATING_SCORE_BONUS);

--- a/src/main/java/com/ureca/snac/trade/service/interfaces/TradeCancelService.java
+++ b/src/main/java/com/ureca/snac/trade/service/interfaces/TradeCancelService.java
@@ -26,5 +26,5 @@ public interface TradeCancelService {
 
     TradeDto cancelRealTimeTrade(Long tradeId, String username, CancelReason reason);
 
-    void refundToBuyerAndPublishEvent(Trade trade, Card card, Member buyer);
+    void refundBuyerEscrow(Trade trade, Card card, Member buyer);
 }


### PR DESCRIPTION
## 변경 사항 요약

거래 생성·확정·취소 서비스에 에스크로 홀드 모델을 연결하여 자금 흐름 정합성 확보

Closes #49

---

## 주요 변경 사항

### 1. Trade 도메인 메서드 추출

**Trade**

- `getPointOrZero()`: null-safe 포인트 조회
- `getMoneyAmount()`: `priceGb - point` 머니 금액 계산
- 서비스 레이어의 null 처리·계산 로직 제거

### 2. 에스크로 흐름 연결

**TradeInitiationServiceImpl**

- `withdrawMoney` / `withdrawPoint` → `moveCompositeToEscrow` (balance → escrow 홀드)
- `WalletRepository` 직접 의존 제거

**TradeProgressServiceImpl**

- `deductCompositeEscrow` (escrow → 소멸) 후 판매자 입금

**TradeCancelServiceImpl**

- `depositMoney` / `depositPoint` 직접 환불 → `releaseCompositeEscrow` (escrow → balance 복원)
- `refundToBuyerAndPublishEvent` → `refundBuyerEscrow` 메서드명 변경

**TradeAutoItemProcessor**

- 자동 환불: `releaseCompositeEscrow`
- 자동 정산: `deductCompositeEscrow` 후 판매자 입금

---

## 동작 흐름

### 구매 확정

```
confirmTrade → deductCompositeEscrow → depositMoney(seller)
```

### 거래 취소·환불

```
cancel → releaseCompositeEscrow → escrow 감소, balance 복원
```

### 자동 처리 (스케줄러)

```
자동 확정: deductCompositeEscrow → depositMoney(seller)
자동 환불: releaseCompositeEscrow → 구매자 balance 복원
```

---

## 기술적 의사결정

### 왜 WalletRepository 직접 의존을 제거하는가?

**문제**
- 서비스가 지갑 엔티티를 직접 조회하여 잔액 차감 → 에스크로 흐름 밖에서 자금이 움직임

**해결**
- WalletService 복합 에스크로 메서드를 통해서만 자금 이동, 서비스 경계 명확화