### PR TITLE
[test] 에스크로 흐름 단위·통합 테스트 추가

### DIFF
--- a/src/test/java/com/ureca/snac/integration/EscrowFlowIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/EscrowFlowIntegrationTest.java
@@ -1,0 +1,369 @@
+package com.ureca.snac.integration;
+
+import com.ureca.snac.board.entity.Card;
+import com.ureca.snac.board.entity.constants.CardCategory;
+import com.ureca.snac.board.entity.constants.Carrier;
+import com.ureca.snac.board.entity.constants.SellStatus;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.trade.entity.CancelReason;
+import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.entity.TradeStatus;
+import com.ureca.snac.trade.entity.TradeType;
+import com.ureca.snac.trade.scheduler.TradeAutoItemProcessor;
+import com.ureca.snac.trade.service.TradeAlertService;
+import com.ureca.snac.trade.service.TradeCancelServiceImpl;
+import com.ureca.snac.trade.service.TradeProgressServiceImpl;
+import com.ureca.snac.trade.service.interfaces.PenaltyService;
+import com.ureca.snac.wallet.entity.Wallet;
+import com.ureca.snac.wallet.service.WalletService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 에스크로 전체 흐름 통합 테스트
+ * <p>
+ * processRefund  : 자동 환불 (머니 단독, 머니+포인트 복합)
+ * confirmTrade   : 구매자 확정 → 에스크로 차감 + 판매자 입금
+ * processPayout  : 자동 정산 → 에스크로 차감 + 판매자 입금
+ * cancelRealTimeTrade (PAYMENT_CONFIRMED) : 에스크로 복원
+ * 동시성 : 잔액 10,000원으로 1,000씩 50스레드 → 정확히 10개만 성공
+ */
+@DisplayName("에스크로 흐름 통합 테스트")
+class EscrowFlowIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private WalletService walletService;
+
+    @Autowired
+    private TradeProgressServiceImpl tradeProgressService;
+
+    @Autowired
+    private TradeCancelServiceImpl tradeCancelService;
+
+    @Autowired
+    private TradeAutoItemProcessor tradeAutoItemProcessor;
+
+    @MockitoBean
+    private PenaltyService penaltyService;
+
+    @MockitoBean
+    private TradeAlertService tradeAlertService;
+
+    private Member buyer;
+    private Member seller;
+
+    private static final int PRICE_GB = 10_000;
+    private static final long MONEY_AMOUNT = 10_000L;
+    private static final int THREAD_COUNT = 50;
+
+    @BeforeEach
+    void setUpMembers() {
+        buyer = createMemberWithWallet("escrow_buyer_");
+        seller = createMemberWithWallet("escrow_seller_");
+    }
+
+    // processRefund : 자동 환불
+    @Nested
+    @DisplayName("processRefund (자동 환불)")
+    class ProcessRefundTest {
+
+        @Test
+        @DisplayName("머니 에스크로 → 환불 후 buyer 잔액 복원")
+        void processRefund_moneyOnly_restoresBuyerBalance() {
+            // given
+            walletService.depositMoney(buyer.getId(), MONEY_AMOUNT);
+            walletService.moveCompositeToEscrow(buyer.getId(), MONEY_AMOUNT, 0L);
+
+            Card card = saveCard(seller, PRICE_GB, SellStatus.TRADING);
+            Trade trade = saveTrade(buyer, seller, card, PRICE_GB, 0, TradeStatus.PAYMENT_CONFIRMED);
+
+            // when
+            tradeAutoItemProcessor.processRefund(trade);
+
+            // then: 에스크로 → 잔액 복원 (핵심 금융 불변식)
+            Wallet buyerWallet = walletRepository.findByMemberId(buyer.getId()).orElseThrow();
+            assertThat(buyerWallet.getMoneyBalance()).isEqualTo(MONEY_AMOUNT);
+            assertThat(buyerWallet.getMoneyEscrow()).isZero();
+        }
+
+        @Test
+        @DisplayName("머니+포인트 복합 에스크로 → 환불 후 buyer 잔액·포인트 모두 복원")
+        void processRefund_composite_restoresBothAssets() {
+            // given: priceGb=1000, point=200 → money=800, point=200
+            int priceGb = 1_000;
+            int point = 200;
+            long moneyToUse = priceGb - point;
+
+            walletService.depositMoney(buyer.getId(), moneyToUse);
+            walletService.depositPoint(buyer.getId(), point);
+            walletService.moveCompositeToEscrow(buyer.getId(), moneyToUse, point);
+
+            Card card = saveCard(seller, priceGb, SellStatus.TRADING);
+            Trade trade = saveTrade(buyer, seller, card, priceGb, point, TradeStatus.PAYMENT_CONFIRMED);
+
+            // when
+            tradeAutoItemProcessor.processRefund(trade);
+
+            // then
+            Wallet buyerWallet = walletRepository.findByMemberId(buyer.getId()).orElseThrow();
+            assertThat(buyerWallet.getMoneyBalance()).isEqualTo(moneyToUse);
+            assertThat(buyerWallet.getMoneyEscrow()).isZero();
+            assertThat(buyerWallet.getPointBalance()).isEqualTo(point);
+            assertThat(buyerWallet.getPointEscrow()).isZero();
+        }
+    }
+
+    // confirmTrade : 구매자 확정
+    @Nested
+    @DisplayName("confirmTrade (구매자 확정)")
+    class ConfirmTradeTest {
+
+        @Test
+        @DisplayName("구매자 확정 시 buyer 에스크로 차감, seller 머니 입금, 거래 COMPLETED, 카드 SOLD_OUT")
+        void confirmTrade_deductsEscrowAndPaysSellerMoney() {
+            // given
+            walletService.depositMoney(buyer.getId(), MONEY_AMOUNT);
+            walletService.moveCompositeToEscrow(buyer.getId(), MONEY_AMOUNT, 0L);
+
+            Card card = saveCard(seller, PRICE_GB, SellStatus.TRADING);
+            Trade trade = saveTrade(buyer, seller, card, PRICE_GB, 0, TradeStatus.DATA_SENT);
+
+            // when
+            tradeProgressService.confirmTrade(trade.getId(), buyer.getEmail(), true);
+
+            // then — buyer 에스크로 소멸
+            Wallet buyerWallet = walletRepository.findByMemberId(buyer.getId()).orElseThrow();
+            assertThat(buyerWallet.getMoneyEscrow()).isZero();
+
+            // seller 머니 입금
+            Wallet sellerWallet = walletRepository.findByMemberId(seller.getId()).orElseThrow();
+            assertThat(sellerWallet.getMoneyBalance()).isEqualTo(MONEY_AMOUNT);
+
+            // 거래·카드 상태
+            assertThat(tradeRepository.findById(trade.getId()).orElseThrow().getStatus())
+                    .isEqualTo(TradeStatus.COMPLETED);
+            assertThat(cardRepository.findById(card.getId()).orElseThrow().getSellStatus())
+                    .isEqualTo(SellStatus.SOLD_OUT);
+        }
+
+        @Test
+        @DisplayName("머니+포인트 복합 결제 확정 시 buyer 에스크로 전액 차감, seller 총액 머니 입금")
+        void confirmTrade_composite_deductsBothAndPaysSellerTotalPrice() {
+            // given: priceGb=1000, point=200 → money=800, point=200
+            int priceGb = 1_000;
+            int point = 200;
+            long moneyToUse = priceGb - point;
+
+            walletService.depositMoney(buyer.getId(), moneyToUse);
+            walletService.depositPoint(buyer.getId(), point);
+            walletService.moveCompositeToEscrow(buyer.getId(), moneyToUse, point);
+
+            Card card = saveCard(seller, priceGb, SellStatus.TRADING);
+            Trade trade = saveTrade(buyer, seller, card, priceGb, point, TradeStatus.DATA_SENT);
+
+            // when
+            tradeProgressService.confirmTrade(trade.getId(), buyer.getEmail(), true);
+
+            // then — buyer 에스크로 전액 소멸
+            Wallet buyerWallet = walletRepository.findByMemberId(buyer.getId()).orElseThrow();
+            assertThat(buyerWallet.getMoneyEscrow()).isZero();
+            assertThat(buyerWallet.getPointEscrow()).isZero();
+            assertThat(buyerWallet.getMoneyBalance()).isZero();
+            assertThat(buyerWallet.getPointBalance()).isZero();
+
+            // seller 총액(priceGb) 머니로 입금
+            Wallet sellerWallet = walletRepository.findByMemberId(seller.getId()).orElseThrow();
+            assertThat(sellerWallet.getMoneyBalance()).isEqualTo(priceGb);
+        }
+    }
+
+    // processPayout : 자동 정산
+    @Nested
+    @DisplayName("processPayout (자동 정산)")
+    class ProcessPayoutTest {
+
+        @Test
+        @DisplayName("자동 정산 시 buyer 에스크로 차감, seller 머니 입금, 거래 COMPLETED")
+        void processPayout_deductsEscrowAndPaysSellerMoney() {
+            // given
+            walletService.depositMoney(buyer.getId(), MONEY_AMOUNT);
+            walletService.moveCompositeToEscrow(buyer.getId(), MONEY_AMOUNT, 0L);
+
+            Card card = saveCard(seller, PRICE_GB, SellStatus.TRADING);
+            Trade trade = saveTrade(buyer, seller, card, PRICE_GB, 0, TradeStatus.DATA_SENT);
+
+            // when
+            tradeAutoItemProcessor.processPayout(trade);
+
+            // then — buyer 에스크로 소멸
+            Wallet buyerWallet = walletRepository.findByMemberId(buyer.getId()).orElseThrow();
+            assertThat(buyerWallet.getMoneyEscrow()).isZero();
+
+            // seller 머니 입금
+            Wallet sellerWallet = walletRepository.findByMemberId(seller.getId()).orElseThrow();
+            assertThat(sellerWallet.getMoneyBalance()).isEqualTo(MONEY_AMOUNT);
+
+        }
+
+        @Test
+        @DisplayName("머니+포인트 복합 자동 정산 시 buyer 에스크로 전액 차감, seller 총액 머니 입금")
+        void processPayout_composite_deductsBothAndPaysSellerTotalPrice() {
+            // given: priceGb=1000, point=200 → money=800, point=200
+            int priceGb = 1_000;
+            int point = 200;
+            long moneyToUse = priceGb - point;
+
+            walletService.depositMoney(buyer.getId(), moneyToUse);
+            walletService.depositPoint(buyer.getId(), point);
+            walletService.moveCompositeToEscrow(buyer.getId(), moneyToUse, point);
+
+            Card card = saveCard(seller, priceGb, SellStatus.TRADING);
+            Trade trade = saveTrade(buyer, seller, card, priceGb, point, TradeStatus.DATA_SENT);
+
+            // when
+            tradeAutoItemProcessor.processPayout(trade);
+
+            // then — buyer 에스크로 전액 소멸
+            Wallet buyerWallet = walletRepository.findByMemberId(buyer.getId()).orElseThrow();
+            assertThat(buyerWallet.getMoneyEscrow()).isZero();
+            assertThat(buyerWallet.getPointEscrow()).isZero();
+
+            // seller 총액(priceGb) 머니로 입금
+            Wallet sellerWallet = walletRepository.findByMemberId(seller.getId()).orElseThrow();
+            assertThat(sellerWallet.getMoneyBalance()).isEqualTo(priceGb);
+        }
+    }
+
+    // cancelRealTimeTrade : PAYMENT_CONFIRMED 취소
+    @Nested
+    @DisplayName("cancelRealTimeTrade (PAYMENT_CONFIRMED 취소)")
+    class CancelRealTimeTradeTest {
+
+        @Test
+        @DisplayName("PAYMENT_CONFIRMED 취소 시 에스크로 복원, 거래 CANCELED, 카드 삭제")
+        void cancelRealTimeTrade_paymentConfirmed_releasesEscrowAndDeletesCard() {
+            // given
+            walletService.depositMoney(buyer.getId(), MONEY_AMOUNT);
+            walletService.moveCompositeToEscrow(buyer.getId(), MONEY_AMOUNT, 0L);
+
+            Card card = saveCard(seller, PRICE_GB, SellStatus.TRADING);
+            Trade trade = saveTrade(buyer, seller, card, PRICE_GB, 0, TradeStatus.PAYMENT_CONFIRMED);
+
+            // when
+            tradeCancelService.cancelRealTimeTrade(
+                    trade.getId(), buyer.getEmail(), CancelReason.BUYER_CHANGE_MIND);
+
+            // then — buyer 에스크로 복원
+            Wallet buyerWallet = walletRepository.findByMemberId(buyer.getId()).orElseThrow();
+            assertThat(buyerWallet.getMoneyBalance()).isEqualTo(MONEY_AMOUNT);
+            assertThat(buyerWallet.getMoneyEscrow()).isZero();
+
+            // 거래 취소·카드 삭제
+            assertThat(tradeRepository.findById(trade.getId()).orElseThrow().getStatus())
+                    .isEqualTo(TradeStatus.CANCELED);
+            assertThat(cardRepository.findById(card.getId())).isEmpty();
+        }
+    }
+
+    // 에스크로 이동 동시성
+    @Nested
+    @DisplayName("에스크로 이동 동시성")
+    class EscrowConcurrencyTest {
+
+        @Test
+        @DisplayName("잔액 10,000 / 50스레드 각 1,000씩 에스크로 이동 → 정확히 10개 성공")
+        void moveCompositeToEscrow_concurrently_exactlyTenSucceed() throws InterruptedException {
+            // given: buyer 잔액 10,000
+            walletService.depositMoney(buyer.getId(), MONEY_AMOUNT);
+
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failCount = new AtomicInteger();
+
+            // when: 50스레드 동시에 1,000씩 에스크로 이동
+            runConcurrently(() -> {
+                try {
+                    walletService.moveCompositeToEscrow(buyer.getId(), 1_000L, 0L);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            }, THREAD_COUNT);
+
+            // then: 잔액 소진 · 에스크로 10,000 · 성공 10건
+            Wallet wallet = walletRepository.findByMemberId(buyer.getId()).orElseThrow();
+            assertThat(wallet.getMoneyBalance()).isZero();
+            assertThat(wallet.getMoneyEscrow()).isEqualTo(MONEY_AMOUNT);
+            assertThat(successCount.get()).isEqualTo(10);
+            assertThat(failCount.get()).isEqualTo(40);
+        }
+    }
+
+    // 공통 헬퍼
+    private Card saveCard(Member owner, int price, SellStatus status) {
+        return cardRepository.save(Card.builder()
+                .member(owner)
+                .sellStatus(status)
+                .cardCategory(CardCategory.REALTIME_SELL)
+                .carrier(Carrier.SKT)
+                .dataAmount(10)
+                .price(price)
+                .build());
+    }
+
+    private Trade saveTrade(Member buyer, Member seller, Card card,
+                            int priceGb, int point, TradeStatus status) {
+        return tradeRepository.save(Trade.builder()
+                .cardId(card.getId())
+                .buyer(buyer)
+                .seller(seller)
+                .carrier(Carrier.SKT)
+                .priceGb(priceGb)
+                .dataAmount(10)
+                .status(status)
+                .tradeType(TradeType.REALTIME)
+                .phone("01012345678")
+                .point(point)
+                .build());
+    }
+
+    private void runConcurrently(Runnable task, int threadCount) throws InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    latch.await();
+                    task.run();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+        }
+
+        latch.countDown();
+
+        for (Future<?> future : futures) {
+            try {
+                future.get(30, TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException ignored) {
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(45, TimeUnit.SECONDS);
+    }
+}

--- a/src/test/java/com/ureca/snac/payment/scheduler/PaymentReconciliationSchedulerTest.java
+++ b/src/test/java/com/ureca/snac/payment/scheduler/PaymentReconciliationSchedulerTest.java
@@ -335,6 +335,115 @@ class PaymentReconciliationSchedulerTest {
             verify(paymentAlertService).alertReconciliationAutoCanceled(payment, "pk_11");
             verifyNoInteractions(processor);
         }
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED + Toss 조회 TossRetryableException → 스킵")
+        void shouldSkipCancelRequestedOnRetryableInquiry() {
+            // given
+            Payment payment = createCancelRequestedPayment(12L, "order_12", "pk_12");
+
+            given(paymentRepository.findStalePayments(any(), any(), any()))
+                    .willReturn(List.of(payment));
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_12"))
+                    .willThrow(new TossRetryableException(TossErrorCode.TIMEOUT));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verifyNoInteractions(processor, paymentInternalService, paymentAlertService);
+        }
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED + Toss 조회 ExternalApiException (기록 없음) → completeCancellation + 종료")
+        void shouldCompleteCancellationDirectlyWhenTossHasNoRecord() {
+            // given
+            Payment payment = createCancelRequestedPayment(13L, "order_13", "pk_13");
+
+            given(paymentRepository.findStalePayments(any(), any(), any()))
+                    .willReturn(List.of(payment));
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_13"))
+                    .willThrow(new ExternalApiException(TOSS_API_CALL_ERROR, "NOT_FOUND_PAYMENT"));
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(paymentInternalService).completeCancellationForReconciliation(eq(13L), anyString());
+            verify(paymentGatewayAdapter, never()).cancelPayment(anyString(), anyString());
+            verifyNoInteractions(processor, paymentAlertService);
+        }
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED + DONE + cancelPayment TossRetryableException → 스킵")
+        void shouldSkipCancelRequestedWhenTossCancelRetryable() {
+            // given
+            Payment payment = createCancelRequestedPayment(14L, "order_14", "pk_14");
+
+            given(paymentRepository.findStalePayments(any(), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_14", "order_14", "DONE", "카드", 10000L, OffsetDateTime.now());
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_14"))
+                    .willReturn(tossResponse);
+            doThrow(new TossRetryableException(TossErrorCode.TIMEOUT))
+                    .when(paymentGatewayAdapter).cancelPayment(eq("pk_14"), anyString());
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verifyNoInteractions(processor, paymentInternalService, paymentAlertService);
+        }
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED + DONE + cancelPayment ExternalApiException → completeCancellation 진행")
+        void shouldCompleteCancellationWhenTossCancelAlreadyDone() {
+            // given
+            Payment payment = createCancelRequestedPayment(15L, "order_15", "pk_15");
+
+            given(paymentRepository.findStalePayments(any(), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_15", "order_15", "DONE", "카드", 10000L, OffsetDateTime.now());
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_15"))
+                    .willReturn(tossResponse);
+            doThrow(new ExternalApiException(TOSS_API_CALL_ERROR, "ALREADY_CANCELED_PAYMENT"))
+                    .when(paymentGatewayAdapter).cancelPayment(eq("pk_15"), anyString());
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(paymentInternalService).completeCancellationForReconciliation(eq(15L), anyString());
+            verify(paymentAlertService).alertReconciliationAutoCanceled(payment, "pk_15");
+        }
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED + completeCancellation 실패 → alertReconciliationCancelFailed")
+        void shouldAlertCancelFailedWhenCompleteCancellationThrows() {
+            // given
+            Payment payment = createCancelRequestedPayment(16L, "order_16", "pk_16");
+
+            given(paymentRepository.findStalePayments(any(), any(), any()))
+                    .willReturn(List.of(payment));
+
+            TossPaymentInquiryResponse tossResponse = new TossPaymentInquiryResponse(
+                    "pk_16", "order_16", "CANCELED", "카드", 10000L, null);
+            given(paymentGatewayAdapter.inquirePaymentByOrderId("order_16"))
+                    .willReturn(tossResponse);
+            doThrow(new RuntimeException("DB error"))
+                    .when(paymentInternalService).completeCancellationForReconciliation(eq(16L), anyString());
+
+            // when
+            scheduler.reconcileStalePendingPayments();
+
+            // then
+            verify(paymentAlertService).alertReconciliationCancelFailed(
+                    eq(payment), eq("pk_16"), eq("DB error"));
+        }
     }
 
     private Payment createStalePendingPayment(Long id, String orderId) {

--- a/src/test/java/com/ureca/snac/support/IntegrationTestSupport.java
+++ b/src/test/java/com/ureca/snac/support/IntegrationTestSupport.java
@@ -4,17 +4,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ureca.snac.asset.repository.AssetHistoryRepository;
 import com.ureca.snac.auth.service.verify.EmailService;
 import com.ureca.snac.auth.service.verify.SnsService;
+import com.ureca.snac.board.repository.CardRepository;
 import com.ureca.snac.common.notification.SlackNotifier;
 import com.ureca.snac.config.RabbitMQQueue;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.member.repository.SocialLinkRepository;
-import com.ureca.snac.support.fixture.MemberFixture;
-import com.ureca.snac.wallet.entity.Wallet;
 import com.ureca.snac.money.repository.MoneyRechargeRepository;
 import com.ureca.snac.outbox.repository.OutboxRepository;
 import com.ureca.snac.outbox.scheduler.DlqMonitor;
 import com.ureca.snac.payment.repository.PaymentRepository;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.trade.repository.TradeCancelRepository;
+import com.ureca.snac.trade.repository.TradeRepository;
+import com.ureca.snac.wallet.entity.Wallet;
 import com.ureca.snac.wallet.repository.WalletRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.amqp.core.AmqpAdmin;
@@ -148,6 +151,15 @@ public abstract class IntegrationTestSupport {
     protected PaymentRepository paymentRepository;
 
     @Autowired
+    protected TradeCancelRepository tradeCancelRepository;
+
+    @Autowired
+    protected TradeRepository tradeRepository;
+
+    @Autowired
+    protected CardRepository cardRepository;
+
+    @Autowired
     protected MoneyRechargeRepository moneyRechargeRepository;
 
     @Autowired
@@ -176,12 +188,17 @@ public abstract class IntegrationTestSupport {
         // 2. FK 순서 (자식 -> 부모)
         socialLinkRepository.deleteAllInBatch();
 
+        // Trade 관련 (trade_cancel → trade → member, card → member)
+        tradeCancelRepository.deleteAllInBatch();
+        tradeRepository.deleteAllInBatch();
+
         assetHistoryRepository.deleteAllInBatch();
 
         // Payment 관련 (Member FK 존재)
         moneyRechargeRepository.deleteAllInBatch();
         paymentRepository.deleteAllInBatch();
 
+        cardRepository.deleteAllInBatch();
         walletRepository.deleteAllInBatch();
         outboxRepository.deleteAllInBatch();
 

--- a/src/test/java/com/ureca/snac/trade/fixture/TradeFixture.java
+++ b/src/test/java/com/ureca/snac/trade/fixture/TradeFixture.java
@@ -25,6 +25,23 @@ public class TradeFixture {
         return trade;
     }
 
+    public static Trade createAcceptedTradeWithSeller(Long tradeId, Member buyer, Member seller, Long cardId, int priceGb) {
+        Trade trade = Trade.builder()
+                .cardId(cardId)
+                .buyer(buyer)
+                .seller(seller)
+                .carrier(Carrier.SKT)
+                .priceGb(priceGb)
+                .dataAmount(10)
+                .status(TradeStatus.ACCEPTED)
+                .tradeType(TradeType.REALTIME)
+                .phone("01012345678")
+                .point(0)
+                .build();
+        TestReflectionUtils.setField(trade, "id", tradeId);
+        return trade;
+    }
+
     public static Trade createDataSentTrade(Long tradeId, Member buyer, Member seller, Long cardId, int priceGb) {
         Trade trade = Trade.builder()
                 .cardId(cardId)
@@ -42,17 +59,19 @@ public class TradeFixture {
         return trade;
     }
 
-    public static Trade createPaymentConfirmedTrade(Long tradeId, Member buyer, Long cardId, int priceGb) {
+    public static Trade createDataSentTradeWithPoint(
+            Long tradeId, Member buyer, Member seller, Long cardId, int priceGb, int point) {
         Trade trade = Trade.builder()
                 .cardId(cardId)
                 .buyer(buyer)
+                .seller(seller)
                 .carrier(Carrier.SKT)
                 .priceGb(priceGb)
                 .dataAmount(10)
-                .status(TradeStatus.PAYMENT_CONFIRMED)
+                .status(TradeStatus.DATA_SENT)
                 .tradeType(TradeType.REALTIME)
                 .phone("01012345678")
-                .point(0)
+                .point(point)
                 .build();
         TestReflectionUtils.setField(trade, "id", tradeId);
         return trade;
@@ -70,6 +89,24 @@ public class TradeFixture {
                 .tradeType(TradeType.REALTIME)
                 .phone("01012345678")
                 .point(0)
+                .build();
+        TestReflectionUtils.setField(trade, "id", tradeId);
+        return trade;
+    }
+
+    public static Trade createPaymentConfirmedTradeWithPoint(
+            Long tradeId, Member buyer, Member seller, Long cardId, int priceGb, int point) {
+        Trade trade = Trade.builder()
+                .cardId(cardId)
+                .buyer(buyer)
+                .seller(seller)
+                .carrier(Carrier.SKT)
+                .priceGb(priceGb)
+                .dataAmount(10)
+                .status(TradeStatus.PAYMENT_CONFIRMED)
+                .tradeType(TradeType.REALTIME)
+                .phone("01012345678")
+                .point(point)
                 .build();
         TestReflectionUtils.setField(trade, "id", tradeId);
         return trade;

--- a/src/test/java/com/ureca/snac/trade/scheduler/TradeAutoItemProcessorTest.java
+++ b/src/test/java/com/ureca/snac/trade/scheduler/TradeAutoItemProcessorTest.java
@@ -10,6 +10,7 @@ import com.ureca.snac.trade.fixture.CardFixture;
 import com.ureca.snac.trade.fixture.TradeFixture;
 import com.ureca.snac.trade.service.TradeAlertService;
 import com.ureca.snac.trade.service.interfaces.PenaltyService;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
 import com.ureca.snac.wallet.service.WalletService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +22,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.*;
@@ -31,7 +33,6 @@ import static org.mockito.Mockito.*;
  *
  * @Retryable AOP 동작 검증을 위해 Spring Context를 로드하지만,
  * 모든 협력 객체는 Mock으로 대체하여 단위 기능을 검증함.
- *
  * @Recover 메서드는 예외를 re-throw하지 않으므로,
  * 재시도 횟수와 Slack 알림을 동일 테스트에서 함께 검증함.
  */
@@ -87,14 +88,15 @@ class TradeAutoItemProcessorTest extends RetryTestSupport {
                 willAnswer(inv -> Optional.of(
                         CardFixture.createTradingCard(CARD_ID, seller, PRICE)
                 )).given(cardRepository).findLockedById(anyLong());
-                given(walletService.depositMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {});
+                given(walletService.releaseCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        });
 
                 // when — @Recover가 예외를 삼키므로 정상 반환
                 tradeAutoItemProcessor.processRefund(trade);
 
                 // then
-                verify(walletService, times(3)).depositMoney(anyLong(), anyLong());
+                verify(walletService, times(3)).releaseCompositeEscrow(anyLong(), anyLong(), anyLong());
                 verify(tradeAlertService, times(1)).alertAutoRefundFailure(anyLong(), any());
             }
 
@@ -106,16 +108,18 @@ class TradeAutoItemProcessorTest extends RetryTestSupport {
                 willAnswer(inv -> Optional.of(
                         CardFixture.createTradingCard(CARD_ID, seller, PRICE)
                 )).given(cardRepository).findLockedById(anyLong());
-                given(walletService.depositMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {})
-                        .willThrow(new TransientDataAccessException("DB timeout") {})
-                        .willReturn(5000L);
+                given(walletService.releaseCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        })
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        })
+                        .willReturn(new CompositeBalanceResult(PRICE, 0L, 0L, 0L));
 
                 // when
                 tradeAutoItemProcessor.processRefund(trade);
 
                 // then
-                verify(walletService, times(3)).depositMoney(anyLong(), anyLong());
+                verify(walletService, times(3)).releaseCompositeEscrow(anyLong(), anyLong(), anyLong());
                 verify(tradeAlertService, never()).alertAutoRefundFailure(anyLong(), any());
             }
         }
@@ -137,14 +141,15 @@ class TradeAutoItemProcessorTest extends RetryTestSupport {
                 willAnswer(inv -> Optional.of(
                         CardFixture.createTradingCard(CARD_ID, seller, PRICE)
                 )).given(cardRepository).findLockedById(anyLong());
-                given(walletService.depositMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {});
+                given(walletService.deductCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        });
 
                 // when — @Recover가 예외를 삼키므로 정상 반환
                 tradeAutoItemProcessor.processPayout(trade);
 
                 // then
-                verify(walletService, times(3)).depositMoney(anyLong(), anyLong());
+                verify(walletService, times(3)).deductCompositeEscrow(anyLong(), anyLong(), anyLong());
                 verify(tradeAlertService, times(1)).alertAutoPayoutFailure(anyLong(), any());
             }
 
@@ -156,16 +161,19 @@ class TradeAutoItemProcessorTest extends RetryTestSupport {
                 willAnswer(inv -> Optional.of(
                         CardFixture.createTradingCard(CARD_ID, seller, PRICE)
                 )).given(cardRepository).findLockedById(anyLong());
-                given(walletService.depositMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {})
-                        .willThrow(new TransientDataAccessException("DB timeout") {})
-                        .willReturn(15000L);
+                given(walletService.deductCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        })
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        })
+                        .willReturn(new CompositeBalanceResult(0L, 0L, 0L, 0L));
+                given(walletService.depositMoney(anyLong(), anyLong())).willReturn(15000L);
 
                 // when
                 tradeAutoItemProcessor.processPayout(trade);
 
                 // then
-                verify(walletService, times(3)).depositMoney(anyLong(), anyLong());
+                verify(walletService, times(3)).deductCompositeEscrow(anyLong(), anyLong(), anyLong());
                 verify(tradeAlertService, never()).alertAutoPayoutFailure(anyLong(), any());
             }
         }

--- a/src/test/java/com/ureca/snac/trade/service/TradeCancelServiceImplTest.java
+++ b/src/test/java/com/ureca/snac/trade/service/TradeCancelServiceImplTest.java
@@ -1,0 +1,184 @@
+package com.ureca.snac.trade.service;
+
+import com.ureca.snac.asset.entity.AssetType;
+import com.ureca.snac.asset.service.AssetRecorder;
+import com.ureca.snac.board.entity.Card;
+import com.ureca.snac.board.repository.CardRepository;
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.member.repository.MemberRepository;
+import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.fixture.CardFixture;
+import com.ureca.snac.trade.fixture.TradeFixture;
+import com.ureca.snac.trade.repository.TradeCancelRepository;
+import com.ureca.snac.trade.repository.TradeRepository;
+import com.ureca.snac.trade.service.interfaces.PenaltyService;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
+import com.ureca.snac.wallet.service.WalletService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * TradeCancelServiceImpl 단위 테스트
+ *
+ * @Retryable 미적용 서비스이므로 순수 Mockito 단위 테스트 사용.
+ * 에스크로 환불 메서드(releaseCompositeEscrow) 호출 검증에 집중.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeCancelServiceImpl 단위 테스트")
+class TradeCancelServiceImplTest {
+
+    @InjectMocks
+    private TradeCancelServiceImpl tradeCancelService;
+
+    @Mock
+    private TradeCancelRepository cancelRepo;
+    @Mock
+    private CardRepository cardRepo;
+    @Mock
+    private TradeRepository tradeRepo;
+    @Mock
+    private MemberRepository memberRepo;
+    @Mock
+    private PenaltyService penaltyService;
+    @Mock
+    private WalletService walletService;
+    @Mock
+    private AssetRecorder assetRecorder;
+
+    private Member buyer;
+    private Member seller;
+
+    private static final Long TRADE_ID = 1L;
+    private static final Long CARD_ID = 1L;
+    private static final int PRICE = 10000;
+
+    @BeforeEach
+    void setUp() {
+        buyer = MemberFixture.createMember(1L);
+        seller = MemberFixture.createMember(2L);
+    }
+
+    @Nested
+    @DisplayName("refundBuyerEscrow 메서드")
+    class RefundToBuyerAndPublishEventTest {
+
+        @Test
+        @DisplayName("정상 : 머니만 사용한 거래 취소 시 releaseCompositeEscrow(money, 0) 호출")
+        void refund_moneyOnly_shouldCallReleaseCompositeEscrow() {
+            // given
+            Trade trade = TradeFixture.createPaymentConfirmedTrade(TRADE_ID, buyer, seller, CARD_ID, PRICE);
+            Card card = CardFixture.createTradingCard(CARD_ID, seller, PRICE);
+
+            given(walletService.releaseCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                    .willReturn(new CompositeBalanceResult(PRICE, 0L, 0L, 0L));
+
+            // when
+            tradeCancelService.refundBuyerEscrow(trade, card, buyer);
+
+            // then
+            verify(walletService, times(1)).releaseCompositeEscrow(buyer.getId(), PRICE, 0L);
+            verify(assetRecorder, times(1)).recordTradeCancelRefund(
+                    eq(buyer.getId()), eq(TRADE_ID), anyString(), eq(AssetType.MONEY), eq((long) PRICE), eq((long) PRICE));
+            verify(assetRecorder, never()).recordTradeCancelRefund(
+                    anyLong(), anyLong(), anyString(), eq(AssetType.POINT), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("정상 : 포인트만 사용한 거래 취소 시 releaseCompositeEscrow(0, point) 호출")
+        void refund_pointOnly_shouldCallReleaseCompositeEscrow() {
+            // given: priceGb=5000, point=5000 → moneyToRefund=0, pointToRefund=5000
+            Trade trade = TradeFixture.createPaymentConfirmedTradeWithPoint(TRADE_ID, buyer, seller, CARD_ID, 5000, 5000);
+            Card card = CardFixture.createTradingCard(CARD_ID, seller, 5000);
+
+            given(walletService.releaseCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                    .willReturn(new CompositeBalanceResult(0L, 0L, 5000L, 0L));
+
+            // when
+            tradeCancelService.refundBuyerEscrow(trade, card, buyer);
+
+            // then
+            verify(walletService, times(1)).releaseCompositeEscrow(buyer.getId(), 0L, 5000L);
+            verify(assetRecorder, never()).recordTradeCancelRefund(
+                    anyLong(), anyLong(), anyString(), eq(AssetType.MONEY), anyLong(), anyLong());
+            verify(assetRecorder, times(1)).recordTradeCancelRefund(
+                    eq(buyer.getId()), eq(TRADE_ID), anyString(), eq(AssetType.POINT), eq(5000L), eq(5000L));
+        }
+
+        @Test
+        @DisplayName("정상 : 복합 결제(머니+포인트) 취소 시 releaseCompositeEscrow(money, point) 호출")
+        void refund_composite_shouldCallReleaseCompositeEscrow() {
+            // given: priceGb=10000, point=3000 → moneyToRefund=7000, pointToRefund=3000
+            Trade trade = TradeFixture.createPaymentConfirmedTradeWithPoint(TRADE_ID, buyer, seller, CARD_ID, 10000, 3000);
+            Card card = CardFixture.createTradingCard(CARD_ID, seller, 10000);
+
+            given(walletService.releaseCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                    .willReturn(new CompositeBalanceResult(7000L, 0L, 3000L, 0L));
+
+            // when
+            tradeCancelService.refundBuyerEscrow(trade, card, buyer);
+
+            // then
+            verify(walletService, times(1)).releaseCompositeEscrow(buyer.getId(), 7000L, 3000L);
+            verify(assetRecorder, times(1)).recordTradeCancelRefund(
+                    eq(buyer.getId()), eq(TRADE_ID), anyString(), eq(AssetType.MONEY), eq(7000L), eq(7000L));
+            verify(assetRecorder, times(1)).recordTradeCancelRefund(
+                    eq(buyer.getId()), eq(TRADE_ID), anyString(), eq(AssetType.POINT), eq(3000L), eq(3000L));
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelRealTimeTrade 메서드")
+    class CancelRealTimeTradeTest {
+
+        @Test
+        @DisplayName("정상 : PAYMENT_CONFIRMED 상태 취소 시 에스크로 환불 호출")
+        void cancelRealTimeTrade_whenPaymentConfirmed_shouldReleaseEscrow() {
+            // given
+            Trade trade = TradeFixture.createPaymentConfirmedTrade(TRADE_ID, buyer, seller, CARD_ID, PRICE);
+            Card card = CardFixture.createTradingCard(CARD_ID, seller, PRICE);
+
+            given(memberRepo.findByEmail(anyString())).willReturn(Optional.of(buyer));
+            given(tradeRepo.findLockedById(anyLong())).willReturn(Optional.of(trade));
+            given(cardRepo.findLockedById(anyLong())).willReturn(Optional.of(card));
+            given(walletService.releaseCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                    .willReturn(new CompositeBalanceResult((long) PRICE, 0L, 0L, 0L));
+
+            // when
+            tradeCancelService.cancelRealTimeTrade(TRADE_ID, buyer.getEmail(), com.ureca.snac.trade.entity.CancelReason.BUYER_CHANGE_MIND);
+
+            // then
+            verify(walletService, times(1)).releaseCompositeEscrow(buyer.getId(), (long) PRICE, 0L);
+        }
+
+        @Test
+        @DisplayName("정상 : ACCEPTED 상태(결제 전) 취소 시 에스크로 환불 미호출")
+        void cancelRealTimeTrade_whenAccepted_shouldNotReleaseEscrow() {
+            // given
+            Trade trade = TradeFixture.createAcceptedTradeWithSeller(TRADE_ID, buyer, seller, CARD_ID, PRICE);
+            Card card = CardFixture.createTradingCard(CARD_ID, seller, PRICE);
+
+            given(memberRepo.findByEmail(anyString())).willReturn(Optional.of(buyer));
+            given(tradeRepo.findLockedById(anyLong())).willReturn(Optional.of(trade));
+            given(cardRepo.findLockedById(anyLong())).willReturn(Optional.of(card));
+
+            // when
+            tradeCancelService.cancelRealTimeTrade(TRADE_ID, buyer.getEmail(), com.ureca.snac.trade.entity.CancelReason.BUYER_CHANGE_MIND);
+
+            // then: 결제 전 상태이므로 에스크로 환불 없음
+            verify(walletService, never()).releaseCompositeEscrow(anyLong(), anyLong(), anyLong());
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/trade/service/TradeCancelServiceImplTest.java
+++ b/src/test/java/com/ureca/snac/trade/service/TradeCancelServiceImplTest.java
@@ -157,7 +157,7 @@ class TradeCancelServiceImplTest {
                     .willReturn(new CompositeBalanceResult((long) PRICE, 0L, 0L, 0L));
 
             // when
-            tradeCancelService.cancelRealTimeTrade(TRADE_ID, buyer.getEmail(), com.ureca.snac.trade.entity.CancelReason.BUYER_CHANGE_MIND);
+            tradeCancelService.cancelRealTimeTrade(TRADE_ID, buyer.getEmail(), CancelReason.BUYER_CHANGE_MIND);
 
             // then
             verify(walletService, times(1)).releaseCompositeEscrow(buyer.getId(), (long) PRICE, 0L);

--- a/src/test/java/com/ureca/snac/trade/service/TradeInitiationServiceImplTest.java
+++ b/src/test/java/com/ureca/snac/trade/service/TradeInitiationServiceImplTest.java
@@ -6,9 +6,7 @@ import com.ureca.snac.board.repository.CardRepository;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.support.RetryTestSupport;
-import com.ureca.snac.trade.service.TradeAlertService;
 import com.ureca.snac.support.fixture.MemberFixture;
-import com.ureca.snac.support.fixture.WalletFixture;
 import com.ureca.snac.trade.controller.request.CreateRealTimeTradePaymentRequest;
 import com.ureca.snac.trade.controller.request.CreateTradeRequest;
 import com.ureca.snac.trade.entity.Trade;
@@ -16,8 +14,7 @@ import com.ureca.snac.trade.fixture.CardFixture;
 import com.ureca.snac.trade.fixture.TradeFixture;
 import com.ureca.snac.trade.repository.TradeRepository;
 import com.ureca.snac.trade.service.interfaces.TradeInitiationService;
-import com.ureca.snac.wallet.entity.Wallet;
-import com.ureca.snac.wallet.repository.WalletRepository;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
 import com.ureca.snac.wallet.service.WalletService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,16 +22,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.TransientDataAccessException;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-
 import org.springframework.retry.ExhaustedRetryException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * TradeInitiationServiceImpl 단위 테스트 (Spring Support)
@@ -55,9 +52,6 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
     private MemberRepository memberRepository;
 
     @MockitoBean
-    private WalletRepository walletRepository;
-
-    @MockitoBean
     private CardRepository cardRepository;
 
     @MockitoBean
@@ -76,7 +70,6 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
     private Card tradingCard;
     private Card sellingCard;
     private Trade acceptedTrade;
-    private Wallet wallet;
 
     private static final Long TRADE_ID = 1L;
     private static final Long CARD_ID = 1L;
@@ -89,7 +82,6 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
         tradingCard = CardFixture.createTradingCard(CARD_ID, seller, PRICE);
         sellingCard = CardFixture.createSellingCard(CARD_ID, seller, PRICE);
         acceptedTrade = TradeFixture.createAcceptedTrade(TRADE_ID, buyer, CARD_ID, PRICE);
-        wallet = WalletFixture.createWalletWithId(1L, buyer);
     }
 
     @Nested
@@ -117,16 +109,17 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
                 given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
                 given(tradeRepository.findLockedById(anyLong())).willReturn(Optional.of(acceptedTrade));
                 given(cardRepository.findById(anyLong())).willReturn(Optional.of(tradingCard));
-                given(walletRepository.findByMemberIdWithLock(anyLong())).willReturn(Optional.of(wallet));
-                given(walletService.withdrawMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {});
+
+                given(walletService.moveCompositeToEscrow(anyLong(), anyLong(), anyLong()))
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        });
 
                 // when & then
                 assertThatThrownBy(() ->
                         tradeInitiationService.payRealTimeTrade(request, "buyer@test.com")
                 ).isInstanceOf(TransientDataAccessException.class);
 
-                verify(walletService, times(3)).withdrawMoney(anyLong(), anyLong());
+                verify(walletService, times(3)).moveCompositeToEscrow(anyLong(), anyLong(), anyLong());
             }
 
             @Test
@@ -136,18 +129,20 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
                 given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
                 given(tradeRepository.findLockedById(anyLong())).willReturn(Optional.of(acceptedTrade));
                 given(cardRepository.findById(anyLong())).willReturn(Optional.of(tradingCard));
-                given(walletRepository.findByMemberIdWithLock(anyLong())).willReturn(Optional.of(wallet));
-                given(walletService.withdrawMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {})
-                        .willThrow(new TransientDataAccessException("DB timeout") {})
-                        .willReturn(5000L);
+
+                given(walletService.moveCompositeToEscrow(anyLong(), anyLong(), anyLong()))
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        })
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        })
+                        .willReturn(new CompositeBalanceResult(5000L, 10000L, 0L, 0L));
                 given(tradeRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
                 // when
                 tradeInitiationService.payRealTimeTrade(request, "buyer@test.com");
 
                 // then
-                verify(walletService, times(3)).withdrawMoney(anyLong(), anyLong());
+                verify(walletService, times(3)).moveCompositeToEscrow(anyLong(), anyLong(), anyLong());
             }
 
             @Test
@@ -157,9 +152,10 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
                 given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
                 given(tradeRepository.findLockedById(anyLong())).willReturn(Optional.of(acceptedTrade));
                 given(cardRepository.findById(anyLong())).willReturn(Optional.of(tradingCard));
-                given(walletRepository.findByMemberIdWithLock(anyLong())).willReturn(Optional.of(wallet));
-                given(walletService.withdrawMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {});
+
+                given(walletService.moveCompositeToEscrow(anyLong(), anyLong(), anyLong()))
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        });
 
                 // when & then
                 assertThatThrownBy(() ->
@@ -176,8 +172,8 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
                 given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
                 given(tradeRepository.findLockedById(anyLong())).willReturn(Optional.of(acceptedTrade));
                 given(cardRepository.findById(anyLong())).willReturn(Optional.of(tradingCard));
-                given(walletRepository.findByMemberIdWithLock(anyLong())).willReturn(Optional.of(wallet));
-                given(walletService.withdrawMoney(anyLong(), anyLong()))
+
+                given(walletService.moveCompositeToEscrow(anyLong(), anyLong(), anyLong()))
                         .willThrow(new IllegalStateException("non-retryable error"));
 
                 // when & then
@@ -187,7 +183,7 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
                         tradeInitiationService.payRealTimeTrade(request, "buyer@test.com")
                 ).isInstanceOfAny(IllegalStateException.class, ExhaustedRetryException.class);
 
-                verify(walletService, times(1)).withdrawMoney(anyLong(), anyLong());
+                verify(walletService, times(1)).moveCompositeToEscrow(anyLong(), anyLong(), anyLong());
             }
         }
     }
@@ -212,15 +208,16 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
             // given
             given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
             given(cardRepository.findLockedById(anyLong())).willReturn(Optional.of(sellingCard));
-            given(walletService.withdrawMoney(anyLong(), anyLong()))
-                    .willThrow(new TransientDataAccessException("DB timeout") {});
+            given(walletService.moveCompositeToEscrow(anyLong(), anyLong(), anyLong()))
+                    .willThrow(new TransientDataAccessException("DB timeout") {
+                    });
 
             // when & then
             assertThatThrownBy(() ->
                     tradeInitiationService.createSellTrade(request, "buyer@test.com")
             ).isInstanceOf(TransientDataAccessException.class);
 
-            verify(walletService, times(3)).withdrawMoney(anyLong(), anyLong());
+            verify(walletService, times(3)).moveCompositeToEscrow(anyLong(), anyLong(), anyLong());
         }
 
         @Test
@@ -229,8 +226,9 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
             // given - 3회 모두 실패
             given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
             given(cardRepository.findLockedById(anyLong())).willReturn(Optional.of(sellingCard));
-            given(walletService.withdrawMoney(anyLong(), anyLong()))
-                    .willThrow(new TransientDataAccessException("DB timeout") {});
+            given(walletService.moveCompositeToEscrow(anyLong(), anyLong(), anyLong()))
+                    .willThrow(new TransientDataAccessException("DB timeout") {
+                    });
 
             // when & then
             assertThatThrownBy(() ->
@@ -263,15 +261,16 @@ class TradeInitiationServiceImplTest extends RetryTestSupport {
             // given
             given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
             given(cardRepository.findLockedById(anyLong())).willReturn(Optional.of(pendingCard));
-            given(walletService.withdrawMoney(anyLong(), anyLong()))
-                    .willThrow(new TransientDataAccessException("DB timeout") {});
+            given(walletService.moveCompositeToEscrow(anyLong(), anyLong(), anyLong()))
+                    .willThrow(new TransientDataAccessException("DB timeout") {
+                    });
 
             // when & then
             assertThatThrownBy(() ->
                     tradeInitiationService.createBuyTrade(request, "buyer@test.com")
             ).isInstanceOf(TransientDataAccessException.class);
 
-            verify(walletService, times(3)).withdrawMoney(anyLong(), anyLong());
+            verify(walletService, times(3)).moveCompositeToEscrow(anyLong(), anyLong(), anyLong());
         }
     }
 }

--- a/src/test/java/com/ureca/snac/trade/service/TradeProgressServiceImplTest.java
+++ b/src/test/java/com/ureca/snac/trade/service/TradeProgressServiceImplTest.java
@@ -7,12 +7,12 @@ import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.member.service.MemberService;
 import com.ureca.snac.support.RetryTestSupport;
-import com.ureca.snac.trade.service.TradeAlertService;
 import com.ureca.snac.support.fixture.MemberFixture;
 import com.ureca.snac.trade.fixture.CardFixture;
 import com.ureca.snac.trade.fixture.TradeFixture;
 import com.ureca.snac.trade.repository.TradeRepository;
 import com.ureca.snac.trade.service.interfaces.TradeProgressService;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
 import com.ureca.snac.wallet.service.WalletService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.TransientDataAccessException;
-import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Optional;
@@ -86,6 +85,84 @@ class TradeProgressServiceImplTest extends RetryTestSupport {
     class ConfirmTradeTest {
 
         @Nested
+        @DisplayName("에스크로 차감 동작")
+        class EscrowDeductTest {
+
+            @Test
+            @DisplayName("정상 : 머니만 사용한 거래 확정 시 deductCompositeEscrow(buyer, money, 0) 호출")
+            void confirmTrade_moneyOnly_shouldDeductBuyerEscrow() {
+                // given — priceGb=10000, point=0 → moneyToDeduct=10000, pointToDeduct=0
+                willAnswer(inv -> Optional.of(
+                        TradeFixture.createDataSentTrade(TRADE_ID, buyer, seller, CARD_ID, PRICE)
+                )).given(tradeRepository).findLockedById(anyLong());
+                given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
+                given(walletService.deductCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willReturn(new CompositeBalanceResult(0L, 0L, 0L, 0L));
+                given(walletService.depositMoney(anyLong(), anyLong())).willReturn(20000L);
+                given(walletService.depositPoint(anyLong(), anyLong())).willReturn(500L);
+                willAnswer(inv -> Optional.of(
+                        CardFixture.createTradingCard(CARD_ID, seller, PRICE)
+                )).given(cardRepository).findLockedById(anyLong());
+
+                // when
+                tradeProgressService.confirmTrade(TRADE_ID, "buyer@test.com", true);
+
+                // then
+                verify(walletService, times(1)).deductCompositeEscrow(buyer.getId(), (long) PRICE, 0L);
+                verify(walletService, times(1)).depositMoney(seller.getId(), (long) PRICE);
+            }
+
+            @Test
+            @DisplayName("정상 : 머니+포인트 복합 거래 확정 시 deductCompositeEscrow(buyer, money-point, point) 호출")
+            void confirmTrade_composite_shouldDeductBuyerEscrowWithPoint() {
+                // given — priceGb=10000, point=3000 → moneyToDeduct=7000, pointToDeduct=3000
+                willAnswer(inv -> Optional.of(
+                        TradeFixture.createDataSentTradeWithPoint(TRADE_ID, buyer, seller, CARD_ID, PRICE, 3000)
+                )).given(tradeRepository).findLockedById(anyLong());
+                given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
+                given(walletService.deductCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willReturn(new CompositeBalanceResult(0L, 0L, 0L, 0L));
+                given(walletService.depositMoney(anyLong(), anyLong())).willReturn(20000L);
+                given(walletService.depositPoint(anyLong(), anyLong())).willReturn(500L);
+                willAnswer(inv -> Optional.of(
+                        CardFixture.createTradingCard(CARD_ID, seller, PRICE)
+                )).given(cardRepository).findLockedById(anyLong());
+
+                // when
+                tradeProgressService.confirmTrade(TRADE_ID, "buyer@test.com", true);
+
+                // then — priceGb(10000) - point(3000) = 7000 머니, 3000 포인트
+                verify(walletService, times(1)).deductCompositeEscrow(buyer.getId(), 7000L, 3000L);
+                verify(walletService, times(1)).depositMoney(seller.getId(), (long) PRICE);
+            }
+
+            @Test
+            @DisplayName("정상 : deductCompositeEscrow 장애 시 @Retryable에 의해 재시도")
+            void confirmTrade_shouldRetryOnDeductCompositeEscrowFailure() {
+                // given
+                willAnswer(inv -> Optional.of(
+                        TradeFixture.createDataSentTrade(TRADE_ID, buyer, seller, CARD_ID, PRICE)
+                )).given(tradeRepository).findLockedById(anyLong());
+                given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(buyer));
+                willAnswer(inv -> Optional.of(
+                        CardFixture.createTradingCard(CARD_ID, seller, PRICE)
+                )).given(cardRepository).findLockedById(anyLong());
+                given(walletService.deductCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        });
+
+                // when & then
+                assertThatThrownBy(() ->
+                        tradeProgressService.confirmTrade(TRADE_ID, "buyer@test.com", true)
+                ).isInstanceOf(TransientDataAccessException.class);
+
+                verify(walletService, times(3)).deductCompositeEscrow(anyLong(), anyLong(), anyLong());
+                // depositMoney는 deductCompositeEscrow 성공 이후에 호출되므로, 에스크로 차감 실패 시 미호출
+                verify(walletService, never()).depositMoney(anyLong(), anyLong());
+            }
+        }
+
+        @Nested
         @DisplayName("재시도 동작")
         class RetryBehaviorTest {
 
@@ -100,8 +177,11 @@ class TradeProgressServiceImplTest extends RetryTestSupport {
                 willAnswer(inv -> Optional.of(
                         CardFixture.createTradingCard(CARD_ID, seller, PRICE)
                 )).given(cardRepository).findLockedById(anyLong());
+                given(walletService.deductCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willReturn(new CompositeBalanceResult(0L, 0L, 0L, 0L));
                 given(walletService.depositMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {});
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        });
 
                 // when & then
                 assertThatThrownBy(() ->
@@ -122,9 +202,13 @@ class TradeProgressServiceImplTest extends RetryTestSupport {
                 willAnswer(inv -> Optional.of(
                         CardFixture.createTradingCard(CARD_ID, seller, PRICE)
                 )).given(cardRepository).findLockedById(anyLong());
+                given(walletService.deductCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willReturn(new CompositeBalanceResult(0L, 0L, 0L, 0L));
                 given(walletService.depositMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {})
-                        .willThrow(new TransientDataAccessException("DB timeout") {})
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        })
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        })
                         .willReturn(20000L);
                 given(walletService.depositPoint(anyLong(), anyLong())).willReturn(500L);
 
@@ -146,8 +230,11 @@ class TradeProgressServiceImplTest extends RetryTestSupport {
                 willAnswer(inv -> Optional.of(
                         CardFixture.createTradingCard(CARD_ID, seller, PRICE)
                 )).given(cardRepository).findLockedById(anyLong());
+                given(walletService.deductCompositeEscrow(anyLong(), anyLong(), anyLong()))
+                        .willReturn(new CompositeBalanceResult(0L, 0L, 0L, 0L));
                 given(walletService.depositMoney(anyLong(), anyLong()))
-                        .willThrow(new TransientDataAccessException("DB timeout") {});
+                        .willThrow(new TransientDataAccessException("DB timeout") {
+                        });
 
                 // when & then
                 assertThatThrownBy(() ->

--- a/src/test/java/com/ureca/snac/wallet/entity/AssetBalanceTest.java
+++ b/src/test/java/com/ureca/snac/wallet/entity/AssetBalanceTest.java
@@ -1,0 +1,258 @@
+package com.ureca.snac.wallet.entity;
+
+import com.ureca.snac.wallet.exception.InsufficientBalanceException;
+import com.ureca.snac.wallet.exception.InvalidAmountException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * AssetBalance Value Object 단위 테스트
+ * 잔액(balance)과 에스크로(escrow) 상태 관리의 정확성을 검증한다.
+ */
+class AssetBalanceTest {
+
+    private AssetBalance assetBalance;
+
+    @BeforeEach
+    void setUp() {
+        assetBalance = AssetBalance.init();
+    }
+
+    @Test
+    @DisplayName("init - balance=0, escrow=0 으로 초기화")
+    void init_shouldCreateZeroBalance() {
+        assertThat(assetBalance.getBalance()).isEqualTo(0L);
+        assertThat(assetBalance.getEscrow()).isEqualTo(0L);
+    }
+
+    @Nested
+    @DisplayName("deposit")
+    class DepositTest {
+
+        @Test
+        @DisplayName("정상 : 입금 시 balance 증가")
+        void deposit_shouldIncreaseBalance() {
+            assetBalance.deposit(5000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(5000L);
+        }
+
+        @Test
+        @DisplayName("정상 : 연속 입금 시 누적")
+        void deposit_multipleTimes_shouldAccumulate() {
+            assetBalance.deposit(3000L);
+            assetBalance.deposit(2000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(5000L);
+        }
+
+        @Test
+        @DisplayName("예외 : 0 이하 금액 시 InvalidAmountException")
+        void deposit_zeroAmount_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.deposit(0L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : 음수 금액 시 InvalidAmountException")
+        void deposit_negativeAmount_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.deposit(-1000L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("withdraw")
+    class WithdrawTest {
+
+        @BeforeEach
+        void setUp() {
+            assetBalance.deposit(10000L);
+        }
+
+        @Test
+        @DisplayName("정상 : 출금 시 balance 감소")
+        void withdraw_shouldDecreaseBalance() {
+            assetBalance.withdraw(3000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(7000L);
+        }
+
+        @Test
+        @DisplayName("정상 : 전액 출금")
+        void withdraw_fullAmount_shouldLeaveZero() {
+            assetBalance.withdraw(10000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("예외 : 잔액 부족 시 InsufficientBalanceException")
+        void withdraw_insufficientBalance_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.withdraw(20000L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : 0 이하 금액 시 InvalidAmountException")
+        void withdraw_zeroAmount_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.withdraw(0L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("moveToEscrow")
+    class MoveToEscrowTest {
+
+        @BeforeEach
+        void setUp() {
+            assetBalance.deposit(10000L);
+        }
+
+        @Test
+        @DisplayName("정상 : balance 감소, escrow 증가")
+        void moveToEscrow_shouldTransferBalanceToEscrow() {
+            assetBalance.moveToEscrow(6000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(4000L);
+            assertThat(assetBalance.getEscrow()).isEqualTo(6000L);
+        }
+
+        @Test
+        @DisplayName("정상 : 전액 에스크로 이동")
+        void moveToEscrow_fullAmount() {
+            assetBalance.moveToEscrow(10000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(0L);
+            assertThat(assetBalance.getEscrow()).isEqualTo(10000L);
+        }
+
+        @Test
+        @DisplayName("예외 : 잔액 부족 시 InsufficientBalanceException")
+        void moveToEscrow_insufficientBalance_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.moveToEscrow(20000L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : 0 이하 금액 시 InvalidAmountException")
+        void moveToEscrow_zeroAmount_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.moveToEscrow(0L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("releaseEscrow")
+    class ReleaseEscrowTest {
+
+        @BeforeEach
+        void setUp() {
+            assetBalance.deposit(10000L);
+            assetBalance.moveToEscrow(10000L); // balance=0, escrow=10000
+        }
+
+        @Test
+        @DisplayName("정상 : escrow 감소, balance 증가 (환불)")
+        void releaseEscrow_shouldTransferEscrowToBalance() {
+            assetBalance.releaseEscrow(4000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(4000L);
+            assertThat(assetBalance.getEscrow()).isEqualTo(6000L);
+        }
+
+        @Test
+        @DisplayName("정상 : 전액 에스크로 복원")
+        void releaseEscrow_fullAmount() {
+            assetBalance.releaseEscrow(10000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(10000L);
+            assertThat(assetBalance.getEscrow()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("예외 : 에스크로 부족 시 InsufficientBalanceException")
+        void releaseEscrow_insufficientEscrow_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.releaseEscrow(20000L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : 0 이하 금액 시 InvalidAmountException")
+        void releaseEscrow_zeroAmount_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.releaseEscrow(0L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("deductEscrow")
+    class DeductEscrowTest {
+
+        @BeforeEach
+        void setUp() {
+            assetBalance.deposit(10000L);
+            assetBalance.moveToEscrow(10000L); // balance=0, escrow=10000
+        }
+
+        @Test
+        @DisplayName("정상 : escrow 차감 (소멸), balance 불변")
+        void deductEscrow_shouldDecreaseEscrowOnly() {
+            assetBalance.deductEscrow(7000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(0L);
+            assertThat(assetBalance.getEscrow()).isEqualTo(3000L);
+        }
+
+        @Test
+        @DisplayName("정상 : 전액 에스크로 차감")
+        void deductEscrow_fullAmount() {
+            assetBalance.deductEscrow(10000L);
+
+            assertThat(assetBalance.getBalance()).isEqualTo(0L);
+            assertThat(assetBalance.getEscrow()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("예외 : 에스크로 부족 시 InsufficientBalanceException")
+        void deductEscrow_insufficientEscrow_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.deductEscrow(20000L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : 0 이하 금액 시 InvalidAmountException")
+        void deductEscrow_zeroAmount_shouldThrow() {
+            assertThatThrownBy(() -> assetBalance.deductEscrow(0L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTotal")
+    class GetTotalTest {
+
+        @Test
+        @DisplayName("정상 : balance + escrow 합산")
+        void getTotal_shouldReturnSumOfBalanceAndEscrow() {
+            assetBalance.deposit(10000L);
+            assetBalance.moveToEscrow(3000L);
+
+            assertThat(assetBalance.getTotal()).isEqualTo(10000L);
+            assertThat(assetBalance.getBalance()).isEqualTo(7000L);
+            assertThat(assetBalance.getEscrow()).isEqualTo(3000L);
+        }
+
+        @Test
+        @DisplayName("정상 : 초기 상태에서 total=0")
+        void getTotal_initial_shouldBeZero() {
+            assertThat(assetBalance.getTotal()).isEqualTo(0L);
+        }
+    }
+}

--- a/src/test/java/com/ureca/snac/wallet/service/WalletServiceTest.java
+++ b/src/test/java/com/ureca/snac/wallet/service/WalletServiceTest.java
@@ -2,30 +2,39 @@ package com.ureca.snac.wallet.service;
 
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.support.fixture.WalletFixture;
+import com.ureca.snac.wallet.dto.CompositeBalanceResult;
+import com.ureca.snac.wallet.dto.WalletSummaryResponse;
+import com.ureca.snac.wallet.entity.Wallet;
 import com.ureca.snac.wallet.event.WalletCreatedEvent;
+import com.ureca.snac.wallet.exception.InsufficientBalanceException;
+import com.ureca.snac.wallet.exception.InvalidAmountException;
+import com.ureca.snac.wallet.exception.WalletNotFoundException;
 import com.ureca.snac.wallet.repository.WalletRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 /**
  * WalletService 단위 테스트
- * <p>
- * 지갑 중복 생성 방지 (멱등성)
- * 회원 없음 예외 처리
  */
 @ExtendWith(MockitoExtension.class)
 class WalletServiceTest {
 
-    @InjectMocks
     private WalletServiceImpl walletService;
 
     @Mock
@@ -34,49 +43,454 @@ class WalletServiceTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
-    @Test
-    @DisplayName("멱등성 : 이미 지갑이 있으면 생성 안 함")
-    void createWallet_Idempotent() {
-        // given
-        Member member = MemberFixture.createMember(1L);
+    private SimpleMeterRegistry meterRegistry;
 
-        given(walletRepository.existsByMemberId(member.getId()))
-                .willReturn(true);
-
-        // when
-        walletService.createWallet(member);
-
-        // then
-        verify(walletRepository, times(1))
-                .existsByMemberId(member.getId());
-
-        verify(walletRepository, never())
-                .save(any());
-
-        verify(eventPublisher, never())
-                .publishEvent(any(WalletCreatedEvent.class));
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        walletService = new WalletServiceImpl(walletRepository, eventPublisher, meterRegistry);
     }
 
-    @Test
-    @DisplayName("정상 : 지갑 생성 및 WalletCreatedEvent 발행")
-    void createWallet_Success() {
-        // given
-        Member member = MemberFixture.createMember(1L);
+    @Nested
+    @DisplayName("지갑 생성")
+    class CreateWalletTest {
 
-        given(walletRepository.existsByMemberId(member.getId()))
-                .willReturn(false);
+        @Test
+        @DisplayName("멱등성 : 이미 지갑이 있으면 생성 안 함")
+        void createWallet_Idempotent() {
+            // given
+            Member member = MemberFixture.createMember(1L);
+            given(walletRepository.existsByMemberId(member.getId()))
+                    .willReturn(true);
 
-        // when
-        walletService.createWallet(member);
+            // when
+            walletService.createWallet(member);
 
-        // then
-        verify(walletRepository, times(1))
-                .existsByMemberId(member.getId());
+            // then
+            verify(walletRepository, never())
+                    .save(any());
+            verify(eventPublisher, never())
+                    .publishEvent(any(WalletCreatedEvent.class));
+        }
 
-        verify(walletRepository, times(1))
-                .save(any());
+        @Test
+        @DisplayName("정상 : 지갑 생성 및 WalletCreatedEvent 발행")
+        void createWallet_Success() {
+            // given
+            Member member = MemberFixture.createMember(1L);
+            given(walletRepository.existsByMemberId(member.getId()))
+                    .willReturn(false);
 
-        verify(eventPublisher, times(1))
-                .publishEvent(any(WalletCreatedEvent.class));
+            // when
+            walletService.createWallet(member);
+
+            // then
+            verify(walletRepository, times(1))
+                    .save(any());
+            verify(eventPublisher, times(1))
+                    .publishEvent(any(WalletCreatedEvent.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("단건 입출금 메서드")
+    class SingleOperationTest {
+
+        private Member member;
+        private Wallet wallet;
+
+        @BeforeEach
+        void setUp() {
+            member = MemberFixture.createMember(1L);
+            wallet = WalletFixture.createEmptyWallet(member);
+            wallet.depositMoney(10000L);
+            wallet.depositPoint(5000L);
+        }
+
+        @Test
+        @DisplayName("정상 : depositMoney - 입금 후 잔액 반환")
+        void depositMoney_shouldReturnFinalBalance() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            Long finalBalance = walletService.depositMoney(member.getId(), 3000L);
+
+            // then
+            assertThat(finalBalance).isEqualTo(13000L);
+        }
+
+        @Test
+        @DisplayName("정상 : withdrawMoney - 출금 후 잔액 반환")
+        void withdrawMoney_shouldReturnFinalBalance() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            Long finalBalance = walletService.withdrawMoney(member.getId(), 4000L);
+
+            // then
+            assertThat(finalBalance).isEqualTo(6000L);
+        }
+
+        @Test
+        @DisplayName("예외 : withdrawMoney - 잔액 부족 시 InsufficientBalanceException")
+        void withdrawMoney_insufficientBalance_shouldThrow() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when & then
+            assertThatThrownBy(() -> walletService.withdrawMoney(member.getId(), 20000L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("정상 : depositPoint - 적립 후 잔액 반환")
+        void depositPoint_shouldReturnFinalBalance() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            Long finalBalance = walletService.depositPoint(member.getId(), 2000L);
+
+            // then
+            assertThat(finalBalance).isEqualTo(7000L);
+        }
+
+        @Test
+        @DisplayName("예외 : depositMoney - 지갑 없으면 WalletNotFoundException")
+        void depositMoney_walletNotFound_shouldThrow() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(99L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> walletService.depositMoney(99L, 1000L))
+                    .isInstanceOf(WalletNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("복합 에스크로 메서드")
+    class CompositeEscrowTest {
+
+        private Member member;
+        private Wallet wallet;
+
+        @BeforeEach
+        void setUp() {
+            member = MemberFixture.createMember(1L);
+            wallet = WalletFixture.createEmptyWallet(member);
+            wallet.depositMoney(10000L);
+            wallet.depositPoint(5000L);
+        }
+
+        @Test
+        @DisplayName("정상 : moveCompositeToEscrow - 머니+포인트 에스크로 이동")
+        void moveCompositeToEscrow_shouldMoveBoth() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.moveCompositeToEscrow(member.getId(), 7000L, 3000L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(3000L);
+            assertThat(result.moneyEscrow()).isEqualTo(7000L);
+            assertThat(result.pointBalance()).isEqualTo(2000L);
+            assertThat(result.pointEscrow()).isEqualTo(3000L);
+        }
+
+        @Test
+        @DisplayName("정상 : releaseCompositeEscrow - 머니+포인트 에스크로 복원")
+        void releaseCompositeEscrow_shouldReleaseBoth() {
+            // given
+            wallet.moveMoneyToEscrow(10000L);
+            wallet.movePointToEscrow(5000L);
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.releaseCompositeEscrow(member.getId(), 6000L, 2000L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(6000L);
+            assertThat(result.moneyEscrow()).isEqualTo(4000L);
+            assertThat(result.pointBalance()).isEqualTo(2000L);
+            assertThat(result.pointEscrow()).isEqualTo(3000L);
+        }
+
+        @Test
+        @DisplayName("정상 : deductCompositeEscrow - 머니+포인트 에스크로 차감 (소멸)")
+        void deductCompositeEscrow_shouldDeductBoth() {
+            // given
+            wallet.moveMoneyToEscrow(10000L);
+            wallet.movePointToEscrow(5000L);
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.deductCompositeEscrow(member.getId(), 10000L, 5000L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(0L);
+            assertThat(result.moneyEscrow()).isEqualTo(0L);
+            assertThat(result.pointBalance()).isEqualTo(0L);
+            assertThat(result.pointEscrow()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("정상 : moveCompositeToEscrow - 머니만 사용 (포인트=0)")
+        void moveCompositeToEscrow_moneyOnly_shouldMoveMoneyOnly() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.moveCompositeToEscrow(member.getId(), 5000L, 0L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(5000L);
+            assertThat(result.moneyEscrow()).isEqualTo(5000L);
+            assertThat(result.pointBalance()).isEqualTo(5000L);
+            assertThat(result.pointEscrow()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("정상 : moveCompositeToEscrow - 포인트만 사용 (머니=0)")
+        void moveCompositeToEscrow_pointOnly_shouldMovePointOnly() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.moveCompositeToEscrow(member.getId(), 0L, 3000L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(10000L);
+            assertThat(result.moneyEscrow()).isEqualTo(0L);
+            assertThat(result.pointBalance()).isEqualTo(2000L);
+            assertThat(result.pointEscrow()).isEqualTo(3000L);
+        }
+
+        @Test
+        @DisplayName("예외 : moveCompositeToEscrow - 둘 다 0 이하이면 InvalidAmountException")
+        void moveCompositeToEscrow_bothZero_shouldThrow() {
+            // when & then
+            assertThatThrownBy(() -> walletService.moveCompositeToEscrow(member.getId(), 0L, 0L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+
+        @Test
+        @DisplayName("정상 : releaseCompositeEscrow - 머니만 복원 (포인트=0)")
+        void releaseCompositeEscrow_moneyOnly_shouldReleaseMoneyOnly() {
+            // given
+            wallet.moveMoneyToEscrow(10000L);
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.releaseCompositeEscrow(member.getId(), 5000L, 0L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(5000L);
+            assertThat(result.moneyEscrow()).isEqualTo(5000L);
+            assertThat(result.pointBalance()).isEqualTo(5000L);
+            assertThat(result.pointEscrow()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("정상 : releaseCompositeEscrow - 포인트만 복원 (머니=0)")
+        void releaseCompositeEscrow_pointOnly_shouldReleasePointOnly() {
+            // given
+            wallet.movePointToEscrow(5000L);
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.releaseCompositeEscrow(member.getId(), 0L, 3000L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(10000L);
+            assertThat(result.moneyEscrow()).isEqualTo(0L);
+            assertThat(result.pointBalance()).isEqualTo(3000L);
+            assertThat(result.pointEscrow()).isEqualTo(2000L);
+        }
+
+        @Test
+        @DisplayName("예외 : releaseCompositeEscrow - 둘 다 0 이하이면 InvalidAmountException")
+        void releaseCompositeEscrow_bothZero_shouldThrow() {
+            // when & then
+            assertThatThrownBy(() -> walletService.releaseCompositeEscrow(member.getId(), 0L, 0L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+
+        @Test
+        @DisplayName("정상 : deductCompositeEscrow - 머니만 차감 (포인트=0)")
+        void deductCompositeEscrow_moneyOnly_shouldDeductMoneyOnly() {
+            // given
+            wallet.moveMoneyToEscrow(10000L);
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.deductCompositeEscrow(member.getId(), 10000L, 0L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(0L);
+            assertThat(result.moneyEscrow()).isEqualTo(0L);
+            assertThat(result.pointBalance()).isEqualTo(5000L);
+            assertThat(result.pointEscrow()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("정상 : deductCompositeEscrow - 포인트만 차감 (머니=0)")
+        void deductCompositeEscrow_pointOnly_shouldDeductPointOnly() {
+            // given
+            wallet.movePointToEscrow(5000L);
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            CompositeBalanceResult result = walletService.deductCompositeEscrow(member.getId(), 0L, 5000L);
+
+            // then
+            assertThat(result.moneyBalance()).isEqualTo(10000L);
+            assertThat(result.moneyEscrow()).isEqualTo(0L);
+            assertThat(result.pointBalance()).isEqualTo(0L);
+            assertThat(result.pointEscrow()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("예외 : deductCompositeEscrow - 둘 다 0 이하이면 InvalidAmountException")
+        void deductCompositeEscrow_bothZero_shouldThrow() {
+            // when & then
+            assertThatThrownBy(() -> walletService.deductCompositeEscrow(member.getId(), 0L, 0L))
+                    .isInstanceOf(InvalidAmountException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : moveCompositeToEscrow - 머니 잔액 부족 시 InsufficientBalanceException")
+        void moveCompositeToEscrow_insufficientMoney_shouldThrow() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when & then (잔액 10000, 요청 15000)
+            assertThatThrownBy(() -> walletService.moveCompositeToEscrow(member.getId(), 15000L, 1000L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : moveCompositeToEscrow - 포인트 잔액 부족 시 InsufficientBalanceException")
+        void moveCompositeToEscrow_insufficientPoint_shouldThrow() {
+            // given
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when & then (포인트 잔액 5000, 요청 8000)
+            assertThatThrownBy(() -> walletService.moveCompositeToEscrow(member.getId(), 3000L, 8000L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : releaseCompositeEscrow - 에스크로 잔액 부족 시 InsufficientBalanceException")
+        void releaseCompositeEscrow_insufficientEscrow_shouldThrow() {
+            // given
+            wallet.moveMoneyToEscrow(3000L);
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when & then (에스크로 3000, 요청 5000)
+            assertThatThrownBy(() -> walletService.releaseCompositeEscrow(member.getId(), 5000L, 0L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+
+        @Test
+        @DisplayName("예외 : deductCompositeEscrow - 에스크로 잔액 부족 시 InsufficientBalanceException")
+        void deductCompositeEscrow_insufficientEscrow_shouldThrow() {
+            // given
+            wallet.moveMoneyToEscrow(3000L);
+            given(walletRepository.findByMemberIdWithLock(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when & then (에스크로 3000, 요청 5000)
+            assertThatThrownBy(() -> walletService.deductCompositeEscrow(member.getId(), 5000L, 0L))
+                    .isInstanceOf(InsufficientBalanceException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("조회 메서드")
+    class QueryTest {
+
+        @Test
+        @DisplayName("정상 : getMoneyBalance - 머니 잔액 조회")
+        void getMoneyBalance_shouldReturnBalance() {
+            // given
+            Member member = MemberFixture.createMember(1L);
+            Wallet wallet = WalletFixture.createEmptyWallet(member);
+            wallet.depositMoney(10000L);
+
+            given(walletRepository.findByMemberId(member.getId()))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            long balance = walletService.getMoneyBalance(member.getId());
+
+            // then
+            assertThat(balance).isEqualTo(10000L);
+        }
+
+        @Test
+        @DisplayName("예외 : getMoneyBalance - 지갑 없으면 WalletNotFoundException")
+        void getMoneyBalance_walletNotFound_shouldThrow() {
+            // given
+            given(walletRepository.findByMemberId(99L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> walletService.getMoneyBalance(99L))
+                    .isInstanceOf(WalletNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("정상 : getWalletSummary - 이메일로 지갑 요약 조회")
+        void getWalletSummary_shouldReturnSummary() {
+            // given
+            Member member = MemberFixture.createMember(1L);
+            Wallet wallet = WalletFixture.createEmptyWallet(member);
+            wallet.depositMoney(10000L);
+            wallet.depositPoint(3000L);
+            wallet.moveMoneyToEscrow(2000L);
+            wallet.movePointToEscrow(1000L);
+
+            given(walletRepository.findByMemberEmail("test@test.com"))
+                    .willReturn(Optional.of(wallet));
+
+            // when
+            WalletSummaryResponse response = walletService.getWalletSummary("test@test.com");
+
+            // then
+            assertThat(response.moneyBalance()).isEqualTo(8000L);
+            assertThat(response.pointBalance()).isEqualTo(2000L);
+        }
+
+        @Test
+        @DisplayName("예외 : getWalletSummary - 지갑 없으면 WalletNotFoundException")
+        void getWalletSummary_walletNotFound_shouldThrow() {
+            // given
+            given(walletRepository.findByMemberEmail("unknown@test.com"))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> walletService.getWalletSummary("unknown@test.com"))
+                    .isInstanceOf(WalletNotFoundException.class);
+        }
     }
 }


### PR DESCRIPTION
## 변경 사항 요약

에스크로 홀드·해제·차감 흐름 전반에 대한 단위 테스트 및 통합 테스트 추가

Closes #50

---

## 주요 변경 사항

### 1. Wallet 단위 테스트

**WalletServiceTest**

- `moveCompositeToEscrow` / `releaseCompositeEscrow` / `deductCompositeEscrow` 정상 케이스
- 머니·포인트 잔액 부족 시 예외 발생 케이스

**AssetBalanceTest**

- `AssetBalance` 도메인 단위 테스트

### 2. Trade 단위 테스트

**TradeCancelServiceImplTest**

- 거래 취소 시나리오 단위 테스트 신규 추가

**TradeAutoItemProcessorTest, TradeInitiationServiceImplTest, TradeProgressServiceImplTest**

- 에스크로 흐름 변경에 따른 목 호출 검증 수정

### 3. 에스크로 흐름 통합 테스트

**EscrowFlowIntegrationTest**

- 구매 확정: 머니 단독·포인트 단독·복합 결제 시나리오
- 자동 확정(`processPayout`): 복합 결제 에스크로 차감 후 판매자 정산 검증
- 거래 취소: 에스크로 해제 후 구매자 잔액 복원 검증

---

## 동작 흐름

### 통합 테스트 시나리오

```
구매 → moveCompositeToEscrow → [buyer escrow 확인]
확정 → deductCompositeEscrow → depositMoney(seller) → [잔액 검증]
취소 → releaseCompositeEscrow → [buyer balance 복원 검증]
```