### PR TITLE
[chore] CI 파이프라인 및 에스크로 E2E 테스트 환경 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Upload JaCoCo report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/
+          retention-days: 7

--- a/build.gradle
+++ b/build.gradle
@@ -106,21 +106,6 @@ dependencies {
     implementation 'org.springframework:spring-aspects'
 }
 
-bootRun {
-    def envFile = file('.env')
-    if (envFile.exists()) {
-        envFile.readLines().each { line ->
-            line = line.trim()
-            if (line && !line.startsWith('#') && line.contains('=')) {
-                def idx = line.indexOf('=')
-                def key = line.substring(0, idx).trim()
-                def val = line.substring(idx + 1).trim().replaceAll(/^['"]|['"]$/, '')
-                environment(key, val)
-            }
-        }
-    }
-}
-
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,21 @@ dependencies {
     implementation 'org.springframework:spring-aspects'
 }
 
+bootRun {
+    def envFile = file('.env')
+    if (envFile.exists()) {
+        envFile.readLines().each { line ->
+            line = line.trim()
+            if (line && !line.startsWith('#') && line.contains('=')) {
+                def idx = line.indexOf('=')
+                def key = line.substring(0, idx).trim()
+                def val = line.substring(idx + 1).trim().replaceAll(/^['"]|['"]$/, '')
+                environment(key, val)
+            }
+        }
+    }
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/scripts/e2e-escrow-test.sh
+++ b/scripts/e2e-escrow-test.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 에스크로 흐름 E2E 테스트 스크립트
+# =============================================================================
+# 전제조건:
+#   1. 서버가 loadtest 프로필로 실행 중
+#      ./gradlew bootRun --args='--spring.profiles.active=loadtest'
+#   2. jq 설치: brew install jq
+#
+# 테스트 흐름 2가지:
+#   A. SELL 카드 흐름: 판매자가 SELL 카드 등록 → 구매자가 즉시 구매
+#      (판매자 자동 배정, acceptBuyRequest 불필요)
+#   B. BUY 카드 흐름:  구매자가 BUY 카드 등록 → 구매자가 구매 신청 → 판매자가 수락
+#
+#   이후 공통: mark-data-sent (loadtest 전용, S3·SMS 스킵) → 구매자 확인
+# =============================================================================
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+CARD_PRICE=5000   # 카드 단가 (=구매 금액)
+
+# ── 색상 출력 ────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log_step()  { echo -e "\n${BLUE}══ STEP $1 ══${NC}"; }
+log_ok()    { echo -e " ${GREEN}✓${NC} $1"; }
+log_info()  { echo -e " ${YELLOW}ℹ${NC} $1"; }
+log_error() { echo -e " ${RED}✗ ERROR:${NC} $1"; exit 1; }
+log_res()   { echo "   응답: $(echo "$1" | head -c 200)"; }
+
+# ── JWT 추출 (Authorization 응답 헤더) ───────────────────────────────────────
+extract_token() {
+    grep -i "^authorization:" | sed 's/[Aa]uthorization:[ ]*[Bb]earer //i' | tr -d '\r\n'
+}
+
+# ── API 응답 성공 검증 (2xx 코드 포함 여부) ──────────────────────────────────
+assert_ok() {
+    local resp=$1 label=$2
+    local http_status
+    http_status=$(echo "$resp" | jq -r '.status // empty' 2>/dev/null)
+    if echo "$resp" | jq -e '.code' 2>/dev/null | grep -q "ERROR\|FAIL\|MISMATCH\|NOT_FOUND\|DENIED\|DUPLICATE"; then
+        log_error "$label 실패: $resp"
+    fi
+    # HTTP status 필드가 있으면 OK/CREATED/... 중 하나여야 함
+    if [[ -n "$http_status" ]] && [[ "$http_status" != "OK" && "$http_status" != "CREATED" ]]; then
+        log_error "$label 실패 (status=$http_status): $resp"
+    fi
+}
+
+# ── jq 확인 ──────────────────────────────────────────────────────────────────
+command -v jq >/dev/null 2>&1 || log_error "jq가 필요합니다. brew install jq"
+
+# ── 계정 정보 ────────────────────────────────────────────────────────────────
+BUYER_EMAIL="e2e-buyer@test.com";  BUYER_PW="Test1234!";  BUYER_NICK="buyer01";  BUYER_PHONE="01011111111"
+SELLER_EMAIL="e2e-seller@test.com"; SELLER_PW="Test1234!"; SELLER_NICK="seller01"; SELLER_PHONE="01022222222"
+
+echo ""
+echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${YELLOW}  에스크로 E2E 테스트  |  서버: $BASE_URL${NC}"
+echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo "흐름 선택:"
+echo "  [A] SELL 카드 흐름 - 판매자 SELL 카드 등록 → 구매자 즉시 구매"
+echo "  [B] BUY  카드 흐름 - 구매자 BUY 카드 등록 → 구매자 구매 신청 → 판매자 수락"
+echo ""
+read -p "선택 (A 또는 B): " FLOW
+FLOW=$(echo "$FLOW" | tr '[:lower:]' '[:upper:]')
+[[ "$FLOW" != "A" && "$FLOW" != "B" ]] && log_error "A 또는 B만 입력 가능"
+
+# =============================================================================
+# STEP 1: 계정 생성
+# =============================================================================
+log_step "1. 테스트 계정 생성 (loadtest 전용 엔드포인트)"
+
+create_account() {
+    local email=$1 pw=$2 nick=$3 phone=$4
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "$BASE_URL/api/loadtest/join" \
+        -H "Content-Type: application/json" \
+        -d "{\"email\":\"$email\",\"password\":\"$pw\",\"name\":\"$nick\",\"nickname\":\"$nick\",\"phone\":\"$phone\"}")
+    echo "$http_code"
+}
+
+code=$(create_account "$BUYER_EMAIL" "$BUYER_PW" "$BUYER_NICK" "$BUYER_PHONE")
+[[ "$code" == "200" ]] && log_ok "구매자 생성: $BUYER_EMAIL" || log_info "구매자 이미 존재 (HTTP $code)"
+
+code=$(create_account "$SELLER_EMAIL" "$SELLER_PW" "$SELLER_NICK" "$SELLER_PHONE")
+[[ "$code" == "200" ]] && log_ok "판매자 생성: $SELLER_EMAIL" || log_info "판매자 이미 존재 (HTTP $code)"
+
+log_info "이벤트 체인 대기 (Wallet 생성 → 가입보너스, RabbitMQ 비동기)..."
+sleep 3
+
+# =============================================================================
+# STEP 2: 로그인 → JWT 토큰 획득
+# =============================================================================
+log_step "2. 로그인"
+
+login() {
+    local email=$1 pw=$2
+    curl -s -D - -o /dev/null \
+        -X POST "$BASE_URL/api/login" \
+        -H "Content-Type: application/json" \
+        -d "{\"email\":\"$email\",\"password\":\"$pw\"}" | extract_token
+}
+
+BUYER_TOKEN=$(login "$BUYER_EMAIL" "$BUYER_PW")
+[[ -z "$BUYER_TOKEN" ]] && log_error "구매자 로그인 실패"
+log_ok "구매자 JWT: ${BUYER_TOKEN:0:40}..."
+
+SELLER_TOKEN=$(login "$SELLER_EMAIL" "$SELLER_PW")
+[[ -z "$SELLER_TOKEN" ]] && log_error "판매자 로그인 실패"
+log_ok "판매자 JWT: ${SELLER_TOKEN:0:40}..."
+
+# =============================================================================
+# STEP 3: 구매자 머니 충전 (MockPaymentGatewayAdapter - 항상 성공)
+# =============================================================================
+log_step "3. 구매자 머니 충전 (Mock Toss, ${CARD_PRICE}원)"
+
+prepare_resp=$(curl -s -X POST "$BASE_URL/api/money/recharge/prepare" \
+    -H "Authorization: Bearer $BUYER_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"amount\": $CARD_PRICE}")
+log_res "$prepare_resp"
+
+ORDER_ID=$(echo "$prepare_resp" | jq -r '.data.orderId // empty')
+[[ -z "$ORDER_ID" ]] && log_error "orderId 추출 실패"
+log_ok "orderId: $ORDER_ID"
+
+MOCK_KEY="mock-pk-$(date +%s)"
+success_resp=$(curl -s -X GET \
+    "$BASE_URL/api/money/recharge/success?paymentKey=$MOCK_KEY&orderId=$ORDER_ID&amount=$CARD_PRICE" \
+    -H "Authorization: Bearer $BUYER_TOKEN")
+log_res "$success_resp"
+assert_ok "$success_resp" "머니 충전"
+log_ok "구매자 ${CARD_PRICE}원 충전 완료"
+
+# =============================================================================
+# STEP 4 ~ 5: 카드 등록 + 트레이드 생성 (흐름별 분기)
+# =============================================================================
+
+if [[ "$FLOW" == "A" ]]; then
+    # -------------------------------------------------------------------------
+    # [A] SELL 카드 흐름
+    #   판매자가 SELL 카드 등록 (SellStatus: SELLING)
+    #   구매자가 POST /api/trades/sell 로 구매 → 판매자 자동 배정, PAYMENT_CONFIRMED
+    # -------------------------------------------------------------------------
+    log_step "4A. 판매자 SELL 카드 등록"
+
+    card_resp=$(curl -s -X POST "$BASE_URL/api/cards" \
+        -H "Authorization: Bearer $SELLER_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"cardCategory\":\"SELL\",\"carrier\":\"SKT\",\"dataAmount\":5,\"price\":$CARD_PRICE}")
+    log_res "$card_resp"
+    CARD_ID=$(echo "$card_resp" | jq -r '.data.cardId // empty')
+    [[ -z "$CARD_ID" ]] && log_error "SELL 카드 등록 실패"
+    log_ok "SELL 카드 등록. cardId: $CARD_ID"
+
+    log_step "5A. 구매자 → SELL 카드 구매 (에스크로 차감, 판매자 자동 배정)"
+
+    trade_resp=$(curl -s -X POST "$BASE_URL/api/trades/sell" \
+        -H "Authorization: Bearer $BUYER_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"cardId\":$CARD_ID,\"money\":$CARD_PRICE,\"point\":0}")
+    log_res "$trade_resp"
+    TRADE_ID=$(echo "$trade_resp" | jq -r '.data.tradeId // empty')
+    [[ -z "$TRADE_ID" ]] && log_error "트레이드 생성 실패"
+    log_ok "트레이드 생성. tradeId: $TRADE_ID (PAYMENT_CONFIRMED, 에스크로 ${CARD_PRICE}원)"
+
+else
+    # -------------------------------------------------------------------------
+    # [B] BUY 카드 흐름
+    #   구매자가 BUY 카드 등록 (SellStatus: PENDING)
+    #   구매자가 POST /api/trades/buy 로 구매 신청 → 카드 SELLING으로 전환, PAYMENT_CONFIRMED
+    #   판매자가 POST /api/trades/buy/accept 로 수락 → 판매자 배정, TRADING
+    # -------------------------------------------------------------------------
+    log_step "4B. 구매자 BUY 카드 등록"
+
+    card_resp=$(curl -s -X POST "$BASE_URL/api/cards" \
+        -H "Authorization: Bearer $BUYER_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"cardCategory\":\"BUY\",\"carrier\":\"KT\",\"dataAmount\":3,\"price\":$CARD_PRICE}")
+    log_res "$card_resp"
+    CARD_ID=$(echo "$card_resp" | jq -r '.data.cardId // empty')
+    [[ -z "$CARD_ID" ]] && log_error "BUY 카드 등록 실패"
+    log_ok "BUY 카드 등록. cardId: $CARD_ID"
+
+    log_step "5B-1. 구매자 → 본인 BUY 카드로 구매 신청 (에스크로 차감)"
+
+    trade_resp=$(curl -s -X POST "$BASE_URL/api/trades/buy" \
+        -H "Authorization: Bearer $BUYER_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"cardId\":$CARD_ID,\"money\":$CARD_PRICE,\"point\":0}")
+    log_res "$trade_resp"
+    TRADE_ID=$(echo "$trade_resp" | jq -r '.data.tradeId // empty')
+    [[ -z "$TRADE_ID" ]] && log_error "트레이드 생성 실패"
+    log_ok "트레이드 생성. tradeId: $TRADE_ID (카드 SELLING 전환됨, 에스크로 ${CARD_PRICE}원)"
+
+    log_step "5B-2. 판매자 → BUY 카드 수락 (판매자 배정)"
+
+    accept_resp=$(curl -s -X POST "$BASE_URL/api/trades/buy/accept" \
+        -H "Authorization: Bearer $SELLER_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"cardId\":$CARD_ID}")
+    log_res "$accept_resp"
+    log_ok "판매자 수락 완료 (카드 TRADING, 판매자 배정됨)"
+fi
+
+# =============================================================================
+# STEP 6: 판매자 데이터 전송 (loadtest 전용 엔드포인트 - S3·SMS 스킵)
+# =============================================================================
+log_step "6. 판매자 데이터 전송 (mark-data-sent, loadtest 전용)"
+
+sent_resp=$(curl -s -X POST "$BASE_URL/api/loadtest/trades/$TRADE_ID/mark-data-sent")
+log_res "$sent_resp"
+assert_ok "$sent_resp" "mark-data-sent"
+log_ok "DATA_SENT 상태 전환 완료"
+
+# =============================================================================
+# STEP 7: 구매자 거래 확인 (에스크로 → 판매자 정산)
+# =============================================================================
+log_step "7. 구매자 거래 확인 (에스크로 해제 → 판매자 정산)"
+
+confirm_resp=$(curl -s -X PATCH "$BASE_URL/api/trades/$TRADE_ID/confirm" \
+    -H "Authorization: Bearer $BUYER_TOKEN")
+log_res "$confirm_resp"
+assert_ok "$confirm_resp" "거래 확인"
+log_ok "거래 확인 완료 → 에스크로 ${CARD_PRICE}원 판매자에게 정산"
+
+# =============================================================================
+# STEP 8: 최종 트레이드 상태 확인
+# =============================================================================
+log_step "8. 최종 트레이드 상태"
+
+trade_detail=$(curl -s -X GET "$BASE_URL/api/trades/$TRADE_ID" \
+    -H "Authorization: Bearer $BUYER_TOKEN")
+
+FINAL_STATUS=$(echo "$trade_detail" | jq -r '.data.status // empty')
+echo ""
+echo "$trade_detail" | jq '{tradeId: .data.tradeId, status: .data.status}' 2>/dev/null \
+    || echo "   $trade_detail" | head -c 300
+
+# 트레이드 상태 검증
+[[ "$FINAL_STATUS" == "COMPLETED" ]] \
+    && log_ok "트레이드 상태: COMPLETED ✓" \
+    || log_error "트레이드 상태 기대값 COMPLETED, 실제값: $FINAL_STATUS"
+
+echo ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}  E2E 에스크로 테스트 완료  |  흐름: $FLOW  |  tradeId: $TRADE_ID${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""

--- a/scripts/e2e-escrow-test.sh
+++ b/scripts/e2e-escrow-test.sh
@@ -63,8 +63,12 @@ echo "흐름 선택:"
 echo "  [A] SELL 카드 흐름 - 판매자 SELL 카드 등록 → 구매자 즉시 구매"
 echo "  [B] BUY  카드 흐름 - 구매자 BUY 카드 등록 → 구매자 구매 신청 → 판매자 수락"
 echo ""
-read -p "선택 (A 또는 B): " FLOW
+FLOW=${1:-}
 FLOW=$(echo "$FLOW" | tr '[:lower:]' '[:upper:]')
+if [[ "$FLOW" != "A" && "$FLOW" != "B" ]]; then
+    read -p "선택 (A 또는 B): " FLOW
+    FLOW=$(echo "$FLOW" | tr '[:lower:]' '[:upper:]')
+fi
 [[ "$FLOW" != "A" && "$FLOW" != "B" ]] && log_error "A 또는 B만 입력 가능"
 
 # =============================================================================
@@ -87,9 +91,6 @@ code=$(create_account "$BUYER_EMAIL" "$BUYER_PW" "$BUYER_NICK" "$BUYER_PHONE")
 code=$(create_account "$SELLER_EMAIL" "$SELLER_PW" "$SELLER_NICK" "$SELLER_PHONE")
 [[ "$code" == "200" ]] && log_ok "판매자 생성: $SELLER_EMAIL" || log_info "판매자 이미 존재 (HTTP $code)"
 
-log_info "이벤트 체인 대기 (Wallet 생성 → 가입보너스, RabbitMQ 비동기)..."
-sleep 3
-
 # =============================================================================
 # STEP 2: 로그인 → JWT 토큰 획득
 # =============================================================================
@@ -110,6 +111,17 @@ log_ok "구매자 JWT: ${BUYER_TOKEN:0:40}..."
 SELLER_TOKEN=$(login "$SELLER_EMAIL" "$SELLER_PW")
 [[ -z "$SELLER_TOKEN" ]] && log_error "판매자 로그인 실패"
 log_ok "판매자 JWT: ${SELLER_TOKEN:0:40}..."
+
+log_info "이벤트 체인 대기 (Wallet 생성 → 가입보너스, RabbitMQ 비동기)..."
+elapsed=0; max_wait=15
+while [[ $elapsed -lt $max_wait ]]; do
+    points=$(curl -s "$BASE_URL/api/wallets/summary" \
+        -H "Authorization: Bearer $BUYER_TOKEN" | jq -r '.data.pointBalance // 0' 2>/dev/null)
+    [[ "${points:-0}" -ge 1000 ]] && break
+    sleep 1; elapsed=$((elapsed + 1))
+done
+[[ $elapsed -ge $max_wait ]] && log_error "가입 보너스 지급 타임아웃 (${max_wait}초)"
+log_ok "이벤트 체인 완료 (가입 보너스 ${points}P 지급 확인)"
 
 # =============================================================================
 # STEP 3: 구매자 머니 충전 (MockPaymentGatewayAdapter - 항상 성공)

--- a/src/main/java/com/ureca/snac/loadtest/LoadTestController.java
+++ b/src/main/java/com/ureca/snac/loadtest/LoadTestController.java
@@ -4,11 +4,9 @@ import com.ureca.snac.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import static com.ureca.snac.common.BaseCode.TRADE_DATA_SENT_SUCCESS;
 import static com.ureca.snac.common.BaseCode.USER_SIGNUP_SUCCESS;
 
 @RestController
@@ -18,6 +16,7 @@ import static com.ureca.snac.common.BaseCode.USER_SIGNUP_SUCCESS;
 public class LoadTestController {
 
     private final LoadTestService loadTestService;
+    private final LoadTestTradeService loadTestTradeService;
 
     @PostMapping("/join")
     public ResponseEntity<ApiResponse<Void>> joinForLoadTest(@RequestBody LoadTestJoinRequest request) {
@@ -29,6 +28,15 @@ public class LoadTestController {
                 request.phone()
         );
         return ResponseEntity.ok(ApiResponse.ok(USER_SIGNUP_SUCCESS));
+    }
+
+    /**
+     * E2E 테스트 전용: seller 검증·S3·SMS 전부 스킵하고 상태만 DATA_SENT로 변경
+     */
+    @PostMapping("/trades/{tradeId}/mark-data-sent")
+    public ResponseEntity<ApiResponse<Void>> markDataSent(@PathVariable Long tradeId) {
+        loadTestTradeService.markDataSent(tradeId);
+        return ResponseEntity.ok(ApiResponse.ok(TRADE_DATA_SENT_SUCCESS));
     }
 
     public record LoadTestJoinRequest(

--- a/src/main/java/com/ureca/snac/loadtest/LoadTestTradeService.java
+++ b/src/main/java/com/ureca/snac/loadtest/LoadTestTradeService.java
@@ -1,0 +1,28 @@
+package com.ureca.snac.loadtest;
+
+import com.ureca.snac.common.BaseCode;
+import com.ureca.snac.common.exception.BusinessException;
+import com.ureca.snac.trade.entity.Trade;
+import com.ureca.snac.trade.repository.TradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * E2E 테스트 전용: 트레이드 상태 강제 변경 (seller 검증·S3·SMS 전부 스킵)
+ */
+@Service
+@Profile("loadtest")
+@Transactional
+@RequiredArgsConstructor
+public class LoadTestTradeService {
+
+    private final TradeRepository tradeRepository;
+
+    public void markDataSent(Long tradeId) {
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new BusinessException(BaseCode.TRADE_NOT_FOUND));
+        trade.markDataSent();
+    }
+}

--- a/src/test/java/com/ureca/snac/integration/BrokerRetransmissionIdempotencyIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/BrokerRetransmissionIdempotencyIntegrationTest.java
@@ -1,16 +1,14 @@
 package com.ureca.snac.integration;
 
 import com.ureca.snac.asset.entity.AssetHistory;
+import com.ureca.snac.asset.entity.TransactionDetail;
 import com.ureca.snac.config.RabbitMQQueue;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.support.IntegrationTestSupport;
 import com.ureca.snac.support.fixture.EventFixture;
 import com.ureca.snac.wallet.entity.Wallet;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,9 +23,6 @@ import static org.awaitility.Awaitility.await;
 @DisplayName("브로커 재전송 멱등성 통합 테스트")
 class BrokerRetransmissionIdempotencyIntegrationTest extends IntegrationTestSupport {
 
-    @Autowired
-    private MeterRegistry meterRegistry;
-
     @Test
     @DisplayName("브로커 재전송 시나리오: 동일 메시지 2회 수신 → 포인트 1회만 지급, 자산 내역 1건")
     void shouldGrantBonusOnlyOnce_WhenSameMessageDeliveredTwice() {
@@ -35,33 +30,26 @@ class BrokerRetransmissionIdempotencyIntegrationTest extends IntegrationTestSupp
         Member member = createMemberWithWallet("redelivery_");
         Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
         String payload = EventFixture.walletCreatedEventJson(member.getId(), wallet.getId());
-
-        // 컨텍스트 재사용 대응: 전송 전 카운터 스냅샷
-        Counter counter = meterRegistry.counter(
-                "listener_message_processed_total",
-                "queue", RabbitMQQueue.WALLET_CREATED_QUEUE,
-                "result", "success"
-        );
-        double before = counter.count();
+        String idempotencyKey = AssetHistory.generateIdempotencyKey(
+                TransactionDetail.SIGNUP_BONUS.name(), member.getId());
 
         // when: 동일 payload 2회 전송 (브로커 재전송 시뮬레이션)
         rabbitTemplate.convertAndSend(RabbitMQQueue.WALLET_CREATED_QUEUE, payload);
         rabbitTemplate.convertAndSend(RabbitMQQueue.WALLET_CREATED_QUEUE, payload);
 
-        // then: 두 메시지 모두 처리 완료 대기
-        await().atMost(10, SECONDS).untilAsserted(() ->
-                assertThat(counter.count()).isEqualTo(before + 2)
+        // then: 이 멱등키가 생성될 때까지 대기 (메시지 1 처리 완료 기준)
+        // 카운터 대신 비즈니스 상태로 동기화 → 다른 테스트 in-flight 메시지의 영향 차단
+        await().atMost(15, SECONDS).untilAsserted(() ->
+                assertThat(assetHistoryRepository.existsByIdempotencyKey(idempotencyKey)).isTrue()
         );
 
         // 포인트: 1000 (1회만 입금)
         Wallet updated = walletRepository.findByMemberId(member.getId()).orElseThrow();
         assertThat(updated.getPointBalance()).isEqualTo(1000L);
 
-        // 자산 내역: 1건 (멱등키 unique 제약으로 이중 반영 차단)
-        assertThat(assetHistoryRepository.findAll())
-                .hasSize(1)
-                .first()
-                .extracting(AssetHistory::getIdempotencyKey)
-                .isEqualTo("SIGNUP_BONUS:" + member.getId());
+        // 자산 내역: 이 멱등키로 정확히 1건만 존재
+        assertThat(assetHistoryRepository.findAll().stream()
+                .filter(h -> h.getIdempotencyKey().equals(idempotencyKey))
+                .count()).isEqualTo(1);
     }
 }

--- a/src/test/java/com/ureca/snac/money/service/MoneyDepositorTest.java
+++ b/src/test/java/com/ureca/snac/money/service/MoneyDepositorTest.java
@@ -5,6 +5,7 @@ import com.ureca.snac.infra.dto.response.TossConfirmResponse;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.money.repository.MoneyRechargeRepository;
 import com.ureca.snac.payment.entity.Payment;
+import com.ureca.snac.payment.exception.PaymentAlreadyProcessedPaymentException;
 import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.support.IntegrationTestSupport;
 import com.ureca.snac.support.fixture.MemberFixture;
@@ -136,16 +137,17 @@ class MoneyDepositorTest extends IntegrationTestSupport {
         class IdempotencyTest {
 
             @Test
-            @DisplayName("정상 : 이미 처리된 충전 요청(SUCCESS 상태)은 재시도 없이 즉시 반환")
-            void deposit_ShouldReturnImmediatelyIfAlreadyProcessed() {
+            @DisplayName("정상 : 이미 처리된 충전 요청(SUCCESS 상태)은 PaymentAlreadyProcessedPaymentException 반환")
+            void deposit_ShouldThrowIfAlreadyProcessed() {
                 // given: FOR UPDATE 락 조회 시 이미 SUCCESS 상태인 Payment 반환
                 Payment successPayment = PaymentFixture.createSuccessPayment(member);
                 given(paymentRepository.findByIdForUpdate(any())).willReturn(Optional.of(successPayment));
 
-                // when: 예외 없이 즉시 반환
-                moneyDepositor.deposit(payment, member, tossConfirmResponse);
+                // when & then: 중복 처리 예외 반환 (HTTP 4xx)
+                assertThatThrownBy(() -> moneyDepositor.deposit(payment, member, tossConfirmResponse))
+                        .isInstanceOf(PaymentAlreadyProcessedPaymentException.class);
 
-                // then: MoneyRecharge 저장 호출 안 됨
+                // 입금 처리 호출 안 됨
                 verify(moneyRechargeRepository, never()).save(any());
                 verify(walletService, never()).depositMoney(anyLong(), anyLong());
             }

--- a/src/test/java/com/ureca/snac/trade/service/TradeCancelServiceImplTest.java
+++ b/src/test/java/com/ureca/snac/trade/service/TradeCancelServiceImplTest.java
@@ -7,6 +7,7 @@ import com.ureca.snac.board.repository.CardRepository;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.support.fixture.MemberFixture;
+import com.ureca.snac.trade.entity.CancelReason;
 import com.ureca.snac.trade.entity.Trade;
 import com.ureca.snac.trade.fixture.CardFixture;
 import com.ureca.snac.trade.fixture.TradeFixture;


### PR DESCRIPTION
## 변경 사항 요약

CI 파이프라인 구축 및 에스크로 E2E 테스트 환경 추가, 기존 테스트 결함 수정

Closes #56

---

## 주요 변경 사항

### 1. CI 파이프라인

**.github/workflows/ci.yml**

- main 브랜치 PR 시 자동 테스트 실행
- Testcontainers(MySQL, RabbitMQ, Redis) Docker 기반 통합 테스트 포함
- JaCoCo 리포트 artifact 업로드

### 2. 에스크로 E2E 테스트 환경

**scripts/e2e-escrow-test.sh**

- SELL/BUY 카드 흐름 HTTP 레벨 수동 검증 스크립트
- 계정 생성 → 충전 → 거래 → 데이터 전송 → 확인 전체 흐름 커버

**LoadTestTradeService / LoadTestController**

- loadtest 프로필 전용 `mark-data-sent` 엔드포인트 (seller 검증·S3·SMS 스킵)

### 3. 테스트 결함 수정

**BrokerRetransmissionIdempotencyIntegrationTest**

- 카운터 기반 동기화 → 멱등키 존재 여부 기반으로 교체

**MoneyDepositorTest**

- 중복 충전 요청 시 예외 반환으로 변경된 구현 반영 (`PaymentAlreadyProcessedPaymentException`)

---

## 동작 흐름

### E2E 테스트 흐름 (스크립트)

```
서버 실행(loadtest 프로필) → 계정 생성 → 로그인 → 머니 충전
→ 카드 등록 → 거래 생성 → mark-data-sent → 구매 확인 → COMPLETED 검증
```

### CI 흐름

```
PR to main → GitHub Actions → ./gradlew test → Testcontainers 기동
→ 단위 + 통합 테스트 → JaCoCo 리포트 업로드
```

---

## 기술적 의사결정

### 왜 카운터 기반 동기화를 제거했나?

**문제**

모든 통합 테스트는 같은 Spring 컨텍스트를 공유한다. `MemberJoinEventChainingIntegrationTest`처럼 실제 이벤트 체인을 발행하는 테스트가 앞서 실행되면, 해당 테스트의 `WalletCreatedEvent`가 리스너의 prefetch 버퍼에 남는다. `@BeforeEach cleanup()`의 `purgeAllQueues()`는 큐에 남은 메시지만 제거하며 이미 prefetch된 in-flight 메시지는 제거하지 못한다.

이 in-flight 메시지가 `BrokerRetransmissionIdempotencyIntegrationTest` 실행 도중 처리되면, 카운터가 예상보다 늦게 `before + 2`에 도달하거나 테스트 ordering에 따라 never가 되는 경우가 발생한다. 단독 실행 시에는 해당 오염원이 없어 항상 통과하므로 재현이 어려운 flaky 특성을 가진다.

**해결**

`counter.count() == before + 2` 대신 이 테스트의 memberId에 한정된 멱등키(`SIGNUP_BONUS:{memberId}`)의 DB 존재 여부로 동기화. 다른 테스트 메시지는 다른 memberId를 가지므로 이 조건에 영향을 미치지 않는다. 이후 `assetHistory` 필터도 동일 멱등키 기준으로 변경해 타 테스트 잔존 레코드와 격리.

**비교**

- 카운터: 큐 전체 처리량 기반 → prefetch 오염 취약
- 비즈니스 상태(멱등키): memberId 스코프 → 테스트 간 완전 격리