### PR TITLE
자산 내역 멱등성 안전망 보완 및 예외 처리 의도 명확화

### DIFF
--- a/src/main/java/com/ureca/snac/asset/dto/AssetHistoryListRequest.java
+++ b/src/main/java/com/ureca/snac/asset/dto/AssetHistoryListRequest.java
@@ -4,6 +4,7 @@ import com.ureca.snac.asset.entity.AssetType;
 import com.ureca.snac.asset.entity.TransactionCategory;
 import com.ureca.snac.asset.entity.TransactionType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 
 /**
@@ -34,6 +35,7 @@ public record AssetHistoryListRequest(
 
         @Schema(description = "한 페이지의 보여줄 수", defaultValue = "20")
         @NotNull
+        @Max(value = 100, message = "조회 사이즈는 100을 초과할 수 없습니다.")
         Integer size
 ) {
 }

--- a/src/main/java/com/ureca/snac/asset/dto/AssetHistoryListRequest.java
+++ b/src/main/java/com/ureca/snac/asset/dto/AssetHistoryListRequest.java
@@ -5,6 +5,7 @@ import com.ureca.snac.asset.entity.TransactionCategory;
 import com.ureca.snac.asset.entity.TransactionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 /**
@@ -35,6 +36,7 @@ public record AssetHistoryListRequest(
 
         @Schema(description = "한 페이지의 보여줄 수", defaultValue = "20")
         @NotNull
+        @Min(value = 1, message = "조회 사이즈는 1 이상이어야 합니다.")
         @Max(value = 100, message = "조회 사이즈는 100을 초과할 수 없습니다.")
         Integer size
 ) {

--- a/src/main/java/com/ureca/snac/asset/service/AssetRecorderImpl.java
+++ b/src/main/java/com/ureca/snac/asset/service/AssetRecorderImpl.java
@@ -10,6 +10,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -119,14 +120,18 @@ public class AssetRecorderImpl implements AssetRecorder {
     private void saveWithIdempotency(AssetHistory history) {
         String idempotencyKey = history.getIdempotencyKey();
         if (assetHistoryRepository.existsByIdempotencyKey(idempotencyKey)) {
-            log.warn("[자산 내역 기록] 중복 요청 무시 (멱등성). idempotencyKey: {}", idempotencyKey);
-            Counter.builder("idempotency_duplicate_blocked_total")
-                    .register(meterRegistry)
-                    .increment();
-            return;
+            log.warn("[자산 내역 기록] 중복 요청 감지 (멱등성). idempotencyKey: {}", idempotencyKey);
+            incrementDuplicateCounter();
+            throw new DataIntegrityViolationException("중복 멱등키: " + idempotencyKey);
         }
 
         assetHistoryRepository.save(history);
         log.info("[자산 내역 기록] 저장 완료. idempotencyKey: {}", idempotencyKey);
+    }
+
+    private void incrementDuplicateCounter() {
+        Counter.builder("idempotency_duplicate_blocked_total")
+                .register(meterRegistry)
+                .increment();
     }
 }

--- a/src/test/java/com/ureca/snac/asset/service/AssetRecorderTest.java
+++ b/src/test/java/com/ureca/snac/asset/service/AssetRecorderTest.java
@@ -8,16 +8,17 @@ import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.member.exception.MemberNotFoundException;
 import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.support.fixture.MemberFixture;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 
@@ -311,23 +312,44 @@ class AssetRecorderTest {
         }
 
         @Test
-        @DisplayName("멱등성 : 중복 멱등키는 문제")
-        void record_duplicateIdempotencyKey_ignored() {
+        @DisplayName("멱등성 : 중복 멱등키 감지 시 DataIntegrityViolationException 발생")
+        void record_duplicateIdempotencyKey_throwsException() {
             // given
             Long paymentId = 100L;
             String idempotencyKey = "RECHARGE:" + paymentId;
 
             given(assetHistoryRepository.existsByIdempotencyKey(idempotencyKey)).willReturn(true);
 
-            // when
-            assetRecorder.recordMoneyRecharge(member.getId(), paymentId, 10000L, 10000L);
+            // when & then
+            assertThatThrownBy(() ->
+                    assetRecorder.recordMoneyRecharge(member.getId(), paymentId, 10000L, 10000L))
+                    .isInstanceOf(DataIntegrityViolationException.class);
 
-            // then
             verify(assetHistoryRepository, never()).save(any());
 
             // 메트릭 검증
             assertThat(meterRegistry.get("idempotency_duplicate_blocked_total")
                     .counter().count()).isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("멱등성 : DB 유니크 제약 위반(동시성) 시 DataIntegrityViolationException 그대로 전파")
+        void record_dataIntegrityViolation_propagatesDirectly() {
+            // given
+            Long paymentId = 200L;
+            String idempotencyKey = "RECHARGE:" + paymentId;
+
+            given(assetHistoryRepository.existsByIdempotencyKey(idempotencyKey)).willReturn(false);
+
+            doThrow(new DataIntegrityViolationException("Unique constraint violation"))
+                    .when(assetHistoryRepository).save(any());
+
+            // when & then : catch 없이 인프라 예외가 그대로 전파됨
+            assertThatThrownBy(() ->
+                    assetRecorder.recordMoneyRecharge(member.getId(), paymentId, 5000L, 5000L))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+
+            verify(assetHistoryRepository, times(1)).save(any());
         }
     }
 }

--- a/src/test/java/com/ureca/snac/integration/SignupBonusConcurrencyIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/SignupBonusConcurrencyIntegrationTest.java
@@ -39,7 +39,8 @@ class SignupBonusConcurrencyIntegrationTest extends IntegrationTestSupport {
             try {
                 signupBonusService.grantSignupBonus(member.getId());
                 successCount.incrementAndGet();
-            } catch (DataIntegrityViolationException e) {
+            } catch (Exception e) {
+                // 내부에서 예외를 잡을 경우 트랜잭션이 롤백 마킹되어 UnexpectedRollbackException이 발생할 수 있음
                 duplicateCount.incrementAndGet();
             }
         }, THREAD_COUNT);


### PR DESCRIPTION
## 변경 사항 요약

자산 내역 중복 방어의 예외 처리가 의도와 실제 동작이 불일치하는 문제를 JPA 원칙에 맞게 정리

Closes #62

---

## 주요 변경 사항

### 1. 멱등성 예외 처리 정리

**AssetRecorderImpl**

- 중복 감지 시 silent return 제거, 명시적 예외 throw로 트랜잭션 롤백 보장
- 복구 불가능한 UK 위반 try-catch 제거, JPA 자연 전파
- 메트릭 카운터 메서드 추출

### 2. 동시성 통합 테스트 보완

**SignupBonusConcurrencyIntegrationTest**

- 예외 catch 범위를 Exception으로 확장 (UnexpectedRollbackException 대응)

### 3. 페이징 방어

**AssetHistoryListRequest**

- size 필드에 @Max(100) 제약 추가

---

## 동작 흐름

### 멱등성 3중 방어

```
1차: RabbitMQ 순차 처리 → 동시성 자체를 방지
2차: isAlreadyGranted() 사전 조회 → 순차 재시도 차단
3차: DB UK 제약 → REPEATABLE READ 통과한 동시 요청 차단 (JPA 자연 전파로 트랜잭션 롤백)
```

### 동시성 시나리오 (100스레드 테스트 검증)

```
T1: isAlreadyGranted()→false → 비관적 락 획득 → deposit → save → 커밋 (성공)
T2: isAlreadyGranted()→false → 비관적 락 대기 → 획득 → deposit → save → UK 위반 → 트랜잭션 전체 롤백
T3~: isAlreadyGranted()→true → 조기 return (deposit 없음)
결과: wallet=1000, history=1건
```

---

## 기술적 의사결정

### 왜 try-catch를 제거했는가?

**문제**
- `save()` + IDENTITY 전략은 즉시 INSERT 실행
- `@Transactional(REQUIRED)` 참여 트랜잭션에서 예외 발생 시 이미 rollback-only 마킹
- JPA 영속성 컨텍스트가 정의되지 않은 상태에서 catch해봐야 복구 불가능

**해결**
- UK 위반은 catch하지 않고 JPA 자연 전파 → 트랜잭션 전체 롤백
- `existsByIdempotencyKey` 체크에서 감지된 중복은 명시적 예외 throw

**비교**
- try-catch 유지 + 예외 번역: 호출자가 구분해서 처리하지 않으므로 불필요한 추상화
- saveAndFlush(): IDENTITY 전략에서 save()와 동작 동일, redundant flush