### PR TITLE
[test] 낙관적 락 vs 비관적 락 수치 기반 비교 실험

### DIFF
--- a/src/main/java/com/ureca/snac/money/controller/MoneyRechargeController.java
+++ b/src/main/java/com/ureca/snac/money/controller/MoneyRechargeController.java
@@ -29,7 +29,7 @@ public class MoneyRechargeController implements MoneyRechargeSwagger {
     public ResponseEntity<ApiResponse<MoneyRechargePreparedResponse>> prepareRecharge(
             @Valid @RequestBody MoneyRechargeRequest request,
             @UserInfo CustomUserDetails userDetails) {
-        MoneyRechargePreparedResponse response = moneyService.prepareRecharge(request, userDetails.getMember());
+        MoneyRechargePreparedResponse response = moneyService.prepareRecharge(request, userDetails.getUsername());
 
         return ResponseEntity.ok(ApiResponse.of(MONEY_RECHARGE_PREPARE_SUCCESS, response));
     }
@@ -45,7 +45,7 @@ public class MoneyRechargeController implements MoneyRechargeSwagger {
 
         MoneyRechargeSuccessResponse successResponse =
                 moneyService.processRechargeSuccess(
-                        paymentKey, orderId, amount, userDetails.getMember().getId()
+                        paymentKey, orderId, amount, userDetails.getUsername()
                 );
 
         log.info("[결제 성공 처리] 완료, 응답 반환. 주문번호 : {}", orderId);

--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryFacade.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryFacade.java
@@ -14,6 +14,10 @@ import org.springframework.stereotype.Service;
  * @Retryable과 @Transactional을 동일 빈에 선언하면 AOP 프록시 순서가 보장되지 않아
  * TransientDataAccessException 발생 시 트랜잭션이 rollback-only로 마킹된 채 재시도
  * UnexpectedRollbackException 분리된 빈으로 @Retryable을 적용하여 각 재시도가 새 트랜잭션에서 실행되도록 보장
+ * <p>
+ * ObjectOptimisticLockingFailureException은 MoneyDepositor.deposit() 커밋 시점에 발생하므로
+ * WalletServiceImpl.depositMoney()의 @Retryable에서는 잡을 수 없음.
+ * Facade 레벨에서 잡아야 각 재시도가 새 트랜잭션에서 실행됨.
  */
 @Service
 @RequiredArgsConstructor
@@ -22,10 +26,15 @@ public class MoneyDepositorRetryFacade {
     private final MoneyDepositor moneyDepositor;
 
     @Retryable(
+            // [낙관락]
+            // MoneyDepositor.deposit() 커밋 시점에 예외 발생
+            // depositMoney()의 @Retryable은 외부 트랜잭션 합류로 동작 안 하므로 Facade 레벨에서 처리
+            // retryFor = {TransientDataAccessException.class, ObjectOptimisticLockingFailureException.class},
+            // listeners = "walletRetryListener",
             retryFor = {TransientDataAccessException.class},
-            maxAttemptsExpression = "${retry.depositor.max-attempts}",
-            backoff = @Backoff(delayExpression = "${retry.depositor.delay}",
-                    multiplierExpression = "${retry.depositor.multiplier}")
+            maxAttemptsExpression = "${retry.depositor.max-attempts:5}",
+            backoff = @Backoff(delayExpression = "${retry.depositor.delay:50}",
+                    multiplierExpression = "${retry.depositor.multiplier:2.0}")
     )
     public void deposit(Long paymentId, Long memberId, PaymentConfirmResult confirmResult) {
         moneyDepositor.deposit(paymentId, memberId, confirmResult);

--- a/src/main/java/com/ureca/snac/money/service/MoneyService.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyService.java
@@ -1,6 +1,5 @@
 package com.ureca.snac.money.service;
 
-import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.money.dto.MoneyRechargeRequest;
 import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
 import com.ureca.snac.money.dto.MoneyRechargeSuccessResponse;
@@ -9,22 +8,22 @@ public interface MoneyService {
     /**
      * 머니 충전 요청 서비스
      *
-     * @param request 요청 DTO
-     * @param member  요청 회원 (name, email을 Toss 위젯 응답에 포함)
+     * @param request     요청 DTO
+     * @param memberEmail 요청 회원 이메일 (JWTFilter가 transient Member를 제공하므로 email로 수신 후 서비스에서 DB 조회)
      * @return 결제 준비 DTO
      */
-    MoneyRechargePreparedResponse prepareRecharge(MoneyRechargeRequest request, Member member);
+    MoneyRechargePreparedResponse prepareRecharge(MoneyRechargeRequest request, String memberEmail);
 
     /**
      * 토스로부터 성공 콜백 받아서 머니 충전 처리하고 결과 반환
      *
-     * @param paymentKey 토스 결제 키
-     * @param orderId    우리 시스템 주문 번호
-     * @param amount     실제 결제 금액
-     * @param memberId   요청 회원 ID
+     * @param paymentKey  토스 결제 키
+     * @param orderId     우리 시스템 주문 번호
+     * @param amount      실제 결제 금액
+     * @param memberEmail 요청 회원 이메일
      * @return 충전 성공 정보를 담은 DTO
      */
     MoneyRechargeSuccessResponse processRechargeSuccess(
-            String paymentKey, String orderId, Long amount, Long memberId);
+            String paymentKey, String orderId, Long amount, String memberEmail);
 }
 

--- a/src/main/java/com/ureca/snac/money/service/MoneyServiceImpl.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyServiceImpl.java
@@ -2,6 +2,8 @@ package com.ureca.snac.money.service;
 
 import com.ureca.snac.common.exception.InternalServerException;
 import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.member.exception.MemberNotFoundException;
+import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
 import com.ureca.snac.money.dto.MoneyRechargeRequest;
 import com.ureca.snac.money.dto.MoneyRechargeSuccessResponse;
@@ -38,9 +40,15 @@ public class MoneyServiceImpl implements MoneyService {
     private final MoneyDepositorRetryFacade moneyDepositorRetryFacade;
     private final ApplicationEventPublisher eventPublisher;
     private final MeterRegistry meterRegistry;
+    private final MemberRepository memberRepository;
 
     @Override
-    public MoneyRechargePreparedResponse prepareRecharge(MoneyRechargeRequest request, Member member) {
+    public MoneyRechargePreparedResponse prepareRecharge(MoneyRechargeRequest request, String memberEmail) {
+        Member member = memberRepository.findByEmail(memberEmail)
+                .orElseThrow(() -> {
+                    log.error("[머니 충전 준비] 회원 조회 실패. email: {}", memberEmail);
+                    return new MemberNotFoundException();
+                });
 
         log.info("[머니 충전 준비] 시작. 회원 ID : {}, 요청 금액 : {}", member.getId(), request.amount());
 
@@ -67,7 +75,13 @@ public class MoneyServiceImpl implements MoneyService {
      */
     @Override
     public MoneyRechargeSuccessResponse processRechargeSuccess(
-            String paymentKey, String orderId, Long amount, Long memberId) {
+            String paymentKey, String orderId, Long amount, String memberEmail) {
+        Long memberId = memberRepository.findByEmail(memberEmail)
+                .orElseThrow(() -> {
+                    log.error("[머니 충전 처리] 회원 조회 실패. email: {}", memberEmail);
+                    return new MemberNotFoundException();
+                })
+                .getId();
 
         Timer.Sample sample = Timer.start(meterRegistry);
         String status = "success";

--- a/src/main/java/com/ureca/snac/wallet/entity/Wallet.java
+++ b/src/main/java/com/ureca/snac/wallet/entity/Wallet.java
@@ -19,6 +19,10 @@ public class Wallet extends BaseTimeEntity {
     @Column(name = "wallet_id")
     private Long id;
 
+    // [낙관락]
+    // @Version
+    // private Long version;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;

--- a/src/main/java/com/ureca/snac/wallet/service/WalletServiceImpl.java
+++ b/src/main/java/com/ureca/snac/wallet/service/WalletServiceImpl.java
@@ -64,9 +64,19 @@ public class WalletServiceImpl implements WalletService {
 
     @Override
     @Transactional
+    // [낙관락] @Retryable — @Version 충돌 시 재시도
+    // @Retryable(
+    //         retryFor = ObjectOptimisticLockingFailureException.class,
+    //         maxAttempts = 5,
+    //         backoff = @Backoff(delay = 50, multiplier = 2.0),
+    //         listeners = "walletRetryListener"
+    // )
     public long depositMoney(Long memberId, long amount) {
         log.info("[머니 입금] 시작. 회원 ID : {}, 입금액 : {}", memberId, amount);
 
+        // [낙관락] 락 없이 조회 @Version으로 커밋 시점에 충돌 감지
+        // Wallet wallet = findWallet(memberId);
+        // [비관락] FOR UPDATE로 조회 직렬화 보장
         Wallet wallet = findWalletWithLock(memberId);
         wallet.depositMoney(amount);
 

--- a/src/test/java/com/ureca/snac/integration/PaymentAsyncEventIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/PaymentAsyncEventIntegrationTest.java
@@ -6,7 +6,6 @@ import com.ureca.snac.common.event.AggregateType;
 import com.ureca.snac.common.event.EventType;
 import com.ureca.snac.config.AggregateExchangeMapper;
 import com.ureca.snac.config.RabbitMQQueue;
-import com.ureca.snac.payment.port.out.PaymentGatewayPort;
 import com.ureca.snac.infra.fixture.TossResponseFixture;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
@@ -17,6 +16,7 @@ import com.ureca.snac.outbox.entity.OutboxStatus;
 import com.ureca.snac.payment.dto.PaymentCancelResponse;
 import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.port.out.PaymentGatewayPort;
 import com.ureca.snac.payment.service.PaymentInternalService;
 import com.ureca.snac.support.IntegrationTestSupport;
 import com.ureca.snac.support.fixture.EventFixture;
@@ -146,11 +146,13 @@ class PaymentAsyncEventIntegrationTest extends IntegrationTestSupport {
         @DisplayName("성공 : compensateCancellationFailure → Outbox → RabbitMQ → Listener → 보상 완료")
         void shouldCompleteCompensationChain() {
             // given: 충전 완료
+            String email = member.getEmail();
             String paymentKey = "e2e_pk_" + System.currentTimeMillis();
+
             MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
-                    new MoneyRechargeRequest(RECHARGE_AMOUNT), member);
+                    new MoneyRechargeRequest(RECHARGE_AMOUNT), email);
             mockTossConfirm(paymentKey);
-            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, email);
 
             Payment payment = paymentRepository.findByPaymentKeyWithMember(paymentKey).orElseThrow();
             PaymentCancelResponse cancelResponse = PaymentCancelResponseFixture.create(
@@ -190,11 +192,13 @@ class PaymentAsyncEventIntegrationTest extends IntegrationTestSupport {
      * CANCEL_REQUESTED + frozen 상태로 반환 (processCompensation이 CANCELED로 전환)
      */
     private Payment createCancelRequestedPayment() {
+        String email = member.getEmail();
         String paymentKey = "comp_pk_" + System.currentTimeMillis();
+
         MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
-                new MoneyRechargeRequest(RECHARGE_AMOUNT), member);
+                new MoneyRechargeRequest(RECHARGE_AMOUNT), email);
         mockTossConfirm(paymentKey);
-        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, email);
 
         Payment payment = paymentRepository.findByPaymentKeyWithMember(paymentKey).orElseThrow();
 

--- a/src/test/java/com/ureca/snac/integration/PaymentConcurrencyIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/PaymentConcurrencyIntegrationTest.java
@@ -2,7 +2,6 @@ package com.ureca.snac.integration;
 
 import com.ureca.snac.asset.entity.AssetHistory;
 import com.ureca.snac.asset.entity.TransactionCategory;
-import com.ureca.snac.payment.port.out.PaymentGatewayPort;
 import com.ureca.snac.infra.fixture.TossResponseFixture;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
@@ -12,10 +11,11 @@ import com.ureca.snac.money.service.MoneyService;
 import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.entity.PaymentStatus;
 import com.ureca.snac.payment.event.PaymentCancelCompensationEvent;
+import com.ureca.snac.payment.port.out.PaymentGatewayPort;
+import com.ureca.snac.payment.port.out.dto.PaymentCancelResult;
 import com.ureca.snac.payment.service.PaymentInternalService;
 import com.ureca.snac.payment.service.PaymentService;
 import com.ureca.snac.support.IntegrationTestSupport;
-import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
 import com.ureca.snac.wallet.entity.Wallet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,9 +30,8 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -85,7 +84,7 @@ class PaymentConcurrencyIntegrationTest extends IntegrationTestSupport {
             runConcurrently(() -> {
                 try {
                     moneyService.processRechargeSuccess(
-                            paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+                            paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();
@@ -153,7 +152,7 @@ class PaymentConcurrencyIntegrationTest extends IntegrationTestSupport {
             String paymentKey = "conc_comp_pk_" + System.currentTimeMillis();
             MoneyRechargePreparedResponse prepared = prepareRecharge();
             mockTossConfirm(paymentKey);
-            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
 
             // 실제 취소 흐름 재현: prepareForCancellation (CANCEL_REQUESTED + frozen)
             // processCompensation N건이 경쟁 → 1건만 CANCELED 전환, 나머지 early return
@@ -224,13 +223,13 @@ class PaymentConcurrencyIntegrationTest extends IntegrationTestSupport {
     }
 
     private MoneyRechargePreparedResponse prepareRecharge() {
-        return moneyService.prepareRecharge(new MoneyRechargeRequest(RECHARGE_AMOUNT), member);
+        return moneyService.prepareRecharge(new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
     }
 
     private void prepareAndCompleteRecharge(String paymentKey) {
         MoneyRechargePreparedResponse prepared = prepareRecharge();
         mockTossConfirm(paymentKey);
-        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
     }
 
     private void mockTossConfirm(String paymentKey) {
@@ -240,6 +239,6 @@ class PaymentConcurrencyIntegrationTest extends IntegrationTestSupport {
 
     private void mockTossCancel(String paymentKey) {
         given(paymentGatewayPort.cancelPayment(anyString(), anyString()))
-                .willReturn(new com.ureca.snac.payment.port.out.dto.PaymentCancelResult(paymentKey, RECHARGE_AMOUNT, java.time.OffsetDateTime.now(), "동시 취소 테스트"));
+                .willReturn(new PaymentCancelResult(paymentKey, RECHARGE_AMOUNT, OffsetDateTime.now(), "동시 취소 테스트"));
     }
 }

--- a/src/test/java/com/ureca/snac/integration/PaymentSchedulerIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/PaymentSchedulerIntegrationTest.java
@@ -1,8 +1,5 @@
 package com.ureca.snac.integration;
 
-import com.ureca.snac.common.exception.ExternalApiException;
-import com.ureca.snac.payment.port.out.PaymentGatewayPort;
-import com.ureca.snac.payment.exception.AlreadyCanceledPaymentException;
 import com.ureca.snac.infra.fixture.TossResponseFixture;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
@@ -10,6 +7,9 @@ import com.ureca.snac.money.dto.MoneyRechargeRequest;
 import com.ureca.snac.money.service.MoneyService;
 import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.entity.PaymentStatus;
+import com.ureca.snac.payment.exception.AlreadyCanceledPaymentException;
+import com.ureca.snac.payment.exception.PaymentNotFoundException;
+import com.ureca.snac.payment.port.out.PaymentGatewayPort;
 import com.ureca.snac.payment.port.out.exception.GatewayTransientException;
 import com.ureca.snac.payment.scheduler.PaymentReconciliationScheduler;
 import com.ureca.snac.payment.service.PaymentInternalService;
@@ -25,7 +25,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 
-import static com.ureca.snac.common.BaseCode.PAYMENT_GATEWAY_API_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -125,7 +124,7 @@ class PaymentSchedulerIntegrationTest extends IntegrationTestSupport {
             String orderId = stalePayment.getOrderId();
 
             given(paymentGatewayPort.inquirePaymentByOrderId(orderId))
-                    .willThrow(new com.ureca.snac.payment.exception.PaymentNotFoundException());
+                    .willThrow(new PaymentNotFoundException());
 
             // when
             scheduler.reconcileStalePayments();
@@ -195,11 +194,13 @@ class PaymentSchedulerIntegrationTest extends IntegrationTestSupport {
         @DisplayName("멱등성 : 이미 처리된 결제 -> Processor false 반환")
         void shouldSkipAlreadyProcessedPayment() {
             // given: 충전 완료 후 stale로 만들기 (SUCCESS 상태라 Processor가 false 반환)
+            String email = member.getEmail();
             String paymentKey = "pk_idem_" + System.currentTimeMillis();
+
             MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
-                    new MoneyRechargeRequest(RECHARGE_AMOUNT), member);
+                    new MoneyRechargeRequest(RECHARGE_AMOUNT), email);
             mockTossConfirm(paymentKey);
-            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, email);
 
             // Payment를 다시 PENDING으로 변경해서 스케줄러가 잡게 만들지 않음
             // 대신 createdAt을 과거로 -> 하지만 이미 SUCCESS라 Processor가 false 반환 확인
@@ -271,11 +272,12 @@ class PaymentSchedulerIntegrationTest extends IntegrationTestSupport {
 
     private Payment createStaleCancelRequestedPayment() {
         // 충전 완료 (SUCCESS 상태) -> CANCEL_REQUESTED + 머니 동결 (실제 취소 흐름 재현)
+        String email = member.getEmail();
         String paymentKey = "pk_cr_" + System.currentTimeMillis();
         MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
-                new MoneyRechargeRequest(RECHARGE_AMOUNT), member);
+                new MoneyRechargeRequest(RECHARGE_AMOUNT), email);
         mockTossConfirm(paymentKey);
-        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, email);
 
         Payment payment = paymentRepository.findByOrderId(prepared.orderId()).orElseThrow();
         assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
@@ -293,7 +295,7 @@ class PaymentSchedulerIntegrationTest extends IntegrationTestSupport {
 
     private Payment createStalePendingPayment() {
         MoneyRechargePreparedResponse prepared = moneyService.prepareRecharge(
-                new MoneyRechargeRequest(RECHARGE_AMOUNT), member);
+                new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
 
         Payment payment = paymentRepository.findByOrderId(prepared.orderId()).orElseThrow();
 

--- a/src/test/java/com/ureca/snac/integration/PaymentSyncFlowIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/PaymentSyncFlowIntegrationTest.java
@@ -2,7 +2,6 @@ package com.ureca.snac.integration;
 
 import com.ureca.snac.asset.entity.AssetHistory;
 import com.ureca.snac.asset.entity.TransactionCategory;
-import com.ureca.snac.payment.port.out.PaymentGatewayPort;
 import com.ureca.snac.infra.fixture.TossResponseFixture;
 import com.ureca.snac.member.entity.Member;
 import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
@@ -14,9 +13,10 @@ import com.ureca.snac.payment.entity.PaymentStatus;
 import com.ureca.snac.payment.exception.AlreadyUsedRechargeCannotCancelException;
 import com.ureca.snac.payment.exception.PaymentAlreadySuccessException;
 import com.ureca.snac.payment.exception.PaymentNotFoundException;
+import com.ureca.snac.payment.port.out.PaymentGatewayPort;
+import com.ureca.snac.payment.port.out.dto.PaymentCancelResult;
 import com.ureca.snac.payment.service.PaymentService;
 import com.ureca.snac.support.IntegrationTestSupport;
-import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
 import com.ureca.snac.wallet.entity.Wallet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,7 +94,7 @@ class PaymentSyncFlowIntegrationTest extends IntegrationTestSupport {
             mockTossConfirm(paymentKey);
 
             // when
-            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
 
             // then: Payment SUCCESS
             Payment payment = paymentRepository.findByOrderId(prepared.orderId()).orElseThrow();
@@ -122,11 +123,11 @@ class PaymentSyncFlowIntegrationTest extends IntegrationTestSupport {
             String paymentKey = uniquePaymentKey();
             mockTossConfirm(paymentKey);
 
-            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+            moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
 
             // when, then: 두 번째 승인 -> PaymentAlreadySuccessException
             assertThatThrownBy(() ->
-                    moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId())
+                    moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail())
             ).isInstanceOf(PaymentAlreadySuccessException.class);
 
             // Wallet 잔액 1배만 반영
@@ -146,7 +147,7 @@ class PaymentSyncFlowIntegrationTest extends IntegrationTestSupport {
 
             // when, then
             assertThatThrownBy(() ->
-                    moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId())
+                    moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail())
             ).isInstanceOf(RuntimeException.class);
 
             // Payment PENDING 유지
@@ -224,13 +225,13 @@ class PaymentSyncFlowIntegrationTest extends IntegrationTestSupport {
     // ================= Helper ====================
 
     private MoneyRechargePreparedResponse prepareRecharge() {
-        return moneyService.prepareRecharge(new MoneyRechargeRequest(RECHARGE_AMOUNT), member);
+        return moneyService.prepareRecharge(new MoneyRechargeRequest(RECHARGE_AMOUNT), member.getEmail());
     }
 
     private void prepareAndCompleteRecharge(String paymentKey) {
         MoneyRechargePreparedResponse prepared = prepareRecharge();
         mockTossConfirm(paymentKey);
-        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getId());
+        moneyService.processRechargeSuccess(paymentKey, prepared.orderId(), RECHARGE_AMOUNT, member.getEmail());
     }
 
     private void mockTossConfirm(String paymentKey) {
@@ -240,7 +241,7 @@ class PaymentSyncFlowIntegrationTest extends IntegrationTestSupport {
 
     private void mockTossCancel(String paymentKey) {
         given(paymentGatewayPort.cancelPayment(anyString(), anyString()))
-                .willReturn(new com.ureca.snac.payment.port.out.dto.PaymentCancelResult(paymentKey, RECHARGE_AMOUNT, java.time.OffsetDateTime.now(), "고객 요청"));
+                .willReturn(new PaymentCancelResult(paymentKey, RECHARGE_AMOUNT, OffsetDateTime.now(), "고객 요청"));
     }
 
     private String uniquePaymentKey() {

--- a/src/test/java/com/ureca/snac/integration/WalletLockComparisonIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/WalletLockComparisonIntegrationTest.java
@@ -1,0 +1,138 @@
+package com.ureca.snac.integration;
+
+import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.support.IntegrationTestSupport;
+import com.ureca.snac.wallet.entity.Wallet;
+import com.ureca.snac.wallet.service.WalletService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * 낙관적 락 vs 비관적 락 동시성 비교 통합 테스트
+ * <p>
+ * [낙관적 락]
+ * Wallet.@Version + depositMoney() @Retryable(maxAttempts=5)
+ * 측정: successCount=100, retryCount(충돌 재시도 총합), 응답시간 분산
+ * <p>
+ * [비관적 락]
+ * depositMoney() findByMemberIdWithLock() (FOR UPDATE)
+ * 측정: successCount=100, retryCount=0, 응답시간 분산
+ * <p>
+ * 정합성은 동일하게 보장되지만, 고경합 환경에서 낙관락은
+ * 재시도로 응답시간 분산이 현저히 높아짐.
+ */
+@DisplayName("지갑 락 전략 동시성 비교 통합 테스트")
+class WalletLockComparisonIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private WalletService walletService;
+
+    private Member member;
+
+    private static final long DEPOSIT_AMOUNT = 1000L;
+    private static final int THREAD_COUNT = 100;
+
+    @BeforeEach
+    void setUp() {
+        member = createMemberWithWallet("lock_cmp_");
+    }
+
+    @Test
+    @DisplayName("100 스레드 동시 입금 → 전원 성공, 잔액 정합성 보장")
+    void concurrent_deposit_allSucceed_balanceConsistent() throws InterruptedException {
+        // when
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+        ConcurrentLinkedQueue<Long> elapsedTimesMs = new ConcurrentLinkedQueue<>();
+
+        runConcurrently(() -> {
+            long start = System.currentTimeMillis();
+            try {
+                walletService.depositMoney(member.getId(), DEPOSIT_AMOUNT);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                elapsedTimesMs.add(System.currentTimeMillis() - start);
+            }
+        }, THREAD_COUNT);
+
+        // then
+        long retryCount = -1; // 비관락: 재시도 없음. 낙관락 브랜치에서는 WalletRetryListener 복구 후 측정
+
+        LongSummaryStatistics stats = elapsedTimesMs.stream()
+                .mapToLong(Long::longValue)
+                .summaryStatistics();
+
+        Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+        long finalBalance = wallet.getMoneyBalance();
+
+        printResult(successCount.get(), failCount.get(), retryCount, stats, finalBalance);
+
+        // 잔액 정합성: 성공한 건수 × 금액만큼만 정확히 반영됐는가
+        // (낙관락은 재시도 한도 초과 시 실패 건수 발생, 비관락은 0건)
+        assertThat(finalBalance)
+                .as("잔액 = 성공 건수 × 입금액 (팬텀 라이트 없음)")
+                .isEqualTo(DEPOSIT_AMOUNT * successCount.get());
+
+        assertThat(successCount.get() + failCount.get())
+                .as("전체 스레드가 완료됐는가")
+                .isEqualTo(THREAD_COUNT);
+    }
+
+    // ==================== helper ====================
+
+    private void runConcurrently(Runnable task, int threadCount) throws InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    ready.await();
+                    task.run();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+        }
+
+        ready.countDown();
+
+        for (Future<?> future : futures) {
+            try {
+                future.get(60, TimeUnit.SECONDS);
+            } catch (ExecutionException ignored) {
+            } catch (TimeoutException e) {
+                fail("태스크가 60초 내 완료되지 않음: " + e.getMessage());
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(70, TimeUnit.SECONDS);
+    }
+
+    private void printResult(int successCount, int failCount, long retryCount,
+                             LongSummaryStatistics stats, long finalBalance) {
+        System.out.println("\n========== 락 전략 비교 결과 ==========");
+        System.out.printf("성공 건수    : %d / %d%n", successCount, THREAD_COUNT);
+        System.out.printf("실패 건수    : %d  ← 낙관락=재시도 한도 초과, 비관락=0 기대%n", failCount);
+        System.out.printf("재시도 횟수  : %s%n", retryCount >= 0 ? retryCount + " (낙관락 충돌 재시도 총합)" : "N/A (비관락)");
+        System.out.printf("최종 잔액    : %,d원%n", finalBalance);
+        System.out.printf("응답시간(ms) : min=%-4d  max=%-4d  avg=%.1f%n",
+                stats.getMin(), stats.getMax(), stats.getAverage());
+        System.out.println("=========================================\n");
+    }
+}

--- a/src/test/java/com/ureca/snac/money/service/MoneyServiceTest.java
+++ b/src/test/java/com/ureca/snac/money/service/MoneyServiceTest.java
@@ -4,20 +4,22 @@ import com.ureca.snac.common.exception.InternalServerException;
 import com.ureca.snac.infra.exception.TossInvalidCardInfoException;
 import com.ureca.snac.infra.exception.TossNotEnoughBalanceException;
 import com.ureca.snac.member.entity.Member;
+import com.ureca.snac.member.repository.MemberRepository;
 import com.ureca.snac.money.dto.MoneyRechargePreparedResponse;
 import com.ureca.snac.money.dto.MoneyRechargeRequest;
 import com.ureca.snac.money.dto.MoneyRechargeSuccessResponse;
-import com.ureca.snac.payment.dto.PaymentCancelResponse;
 import com.ureca.snac.payment.entity.Payment;
 import com.ureca.snac.payment.event.alert.AutoCancelFailureEvent;
 import com.ureca.snac.payment.exception.AlreadyCanceledPaymentException;
 import com.ureca.snac.payment.exception.PaymentAlreadySuccessException;
 import com.ureca.snac.payment.port.out.PaymentGatewayPort;
+import com.ureca.snac.payment.port.out.dto.GatewayPaymentStatus;
+import com.ureca.snac.payment.port.out.dto.PaymentCancelResult;
 import com.ureca.snac.payment.port.out.dto.PaymentConfirmResult;
+import com.ureca.snac.payment.port.out.dto.PaymentInquiryResult;
 import com.ureca.snac.payment.port.out.exception.GatewayTransientException;
 import com.ureca.snac.payment.service.PaymentService;
 import com.ureca.snac.support.fixture.MemberFixture;
-import com.ureca.snac.support.fixture.PaymentCancelResponseFixture;
 import com.ureca.snac.support.fixture.PaymentFixture;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -60,11 +65,13 @@ class MoneyServiceTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private MemberRepository memberRepository;
+
     private Member member;
     private Payment pendingPayment;
     private PaymentConfirmResult confirmResult;
-    private PaymentCancelResponse cancelResponse;
-    private com.ureca.snac.payment.port.out.dto.PaymentCancelResult cancelResult;
+    private PaymentCancelResult cancelResult;
 
     private static final String ORDER_ID = "snac_order_test_123";
     private static final String PAYMENT_KEY = "test_payment_key";
@@ -75,17 +82,17 @@ class MoneyServiceTest {
         meterRegistry = new SimpleMeterRegistry();
         moneyService = new MoneyServiceImpl(
                 paymentService, paymentGatewayPort,
-                moneyDepositorRetryFacade, eventPublisher, meterRegistry
+                moneyDepositorRetryFacade, eventPublisher, meterRegistry, memberRepository
         );
         member = MemberFixture.createMember(1L);
+        given(memberRepository.findByEmail(member.getEmail())).willReturn(Optional.of(member));
         pendingPayment = PaymentFixture.builder()
                 .id(1L)
                 .member(member)
                 .orderId(ORDER_ID)
                 .amount(AMOUNT)
                 .build();
-        confirmResult = new PaymentConfirmResult(PAYMENT_KEY, "카드", java.time.OffsetDateTime.now());
-        cancelResponse = PaymentCancelResponseFixture.create(PAYMENT_KEY, AMOUNT, "Auto-cancel");
+        confirmResult = new PaymentConfirmResult(PAYMENT_KEY, "카드", OffsetDateTime.now());
     }
 
     @Nested
@@ -105,8 +112,9 @@ class MoneyServiceTest {
 
             given(paymentService.preparePayment(member, AMOUNT)).willReturn(createdPayment);
 
+
             // when
-            MoneyRechargePreparedResponse response = moneyService.prepareRecharge(request, member);
+            MoneyRechargePreparedResponse response = moneyService.prepareRecharge(request, member.getEmail());
 
             // then
             assertThat(response).isNotNull();
@@ -135,7 +143,7 @@ class MoneyServiceTest {
                         .willReturn(confirmResult);
 
                 // when
-                moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId());
+                moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail());
 
                 // then
                 verify(paymentGatewayPort, times(1))
@@ -152,20 +160,18 @@ class MoneyServiceTest {
                 // given
                 given(paymentService.findAndValidateForConfirmation(ORDER_ID, AMOUNT, member.getId()))
                         .willReturn(pendingPayment);
-                
+
                 // 1. 토스가 이미 처리됨 (재요청)
                 given(paymentGatewayPort.confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT))
                         .willThrow(new PaymentAlreadySuccessException());
-                
+
                 // 2. 조회 API로 상태 확인
-                com.ureca.snac.payment.port.out.dto.PaymentInquiryResult inquiryResult = 
-                        new com.ureca.snac.payment.port.out.dto.PaymentInquiryResult(
-                                com.ureca.snac.payment.port.out.dto.GatewayPaymentStatus.DONE,
-                                PAYMENT_KEY, ORDER_ID, AMOUNT, "카드", java.time.OffsetDateTime.now());
+                PaymentInquiryResult inquiryResult =
+                        new PaymentInquiryResult(GatewayPaymentStatus.DONE, PAYMENT_KEY, ORDER_ID, AMOUNT, "카드", OffsetDateTime.now());
                 given(paymentGatewayPort.inquirePaymentByOrderId(ORDER_ID)).willReturn(inquiryResult);
 
                 // when
-                moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId());
+                moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail());
 
                 // then
                 verify(paymentGatewayPort).confirmPayment(PAYMENT_KEY, ORDER_ID, AMOUNT);
@@ -189,7 +195,7 @@ class MoneyServiceTest {
 
                 // when, then
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(PaymentAlreadySuccessException.class);
 
                 // 외부 API 호출 안 함
@@ -207,7 +213,7 @@ class MoneyServiceTest {
 
                 // when, then
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(IllegalArgumentException.class);
 
                 // 외부 API 호출 안 함
@@ -225,7 +231,7 @@ class MoneyServiceTest {
 
                 // when, then
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(IllegalArgumentException.class);
 
                 // 외부 API 호출 안 함
@@ -245,7 +251,7 @@ class MoneyServiceTest {
 
                 // when & then: 예외 전파
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(GatewayTransientException.class);
 
                 // Toss 승인 실패 -> 취소 불필요
@@ -266,7 +272,7 @@ class MoneyServiceTest {
 
                 // when: 예외 없이 성공 응답 반환
                 MoneyRechargeSuccessResponse response =
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId());
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail());
 
                 // then: Auto-Cancel 미호출, 성공 응답
                 assertThat(response.orderId()).isEqualTo(ORDER_ID);
@@ -297,7 +303,7 @@ class MoneyServiceTest {
 
                 // when, then
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(Exception.class);
 
                 // Auto-Cancel 호출 확인 (Toss 승인 성공 후 DB 실패 -> 자동 취소)
@@ -317,7 +323,7 @@ class MoneyServiceTest {
 
                 // when & then: 예외 발생, cancelPayment 호출 안 됨
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(TossInvalidCardInfoException.class);
 
                 // Toss 승인 실패 -> 취소 불필요 (돈 안 빠짐)
@@ -336,7 +342,7 @@ class MoneyServiceTest {
 
                 // when & then: 예외 발생, cancelPayment 호출 안 됨
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(TossNotEnoughBalanceException.class);
 
                 // Toss 승인 실패 -> 취소 불필요 (돈 안 빠짐)
@@ -357,7 +363,7 @@ class MoneyServiceTest {
 
                 // when & then: InternalServerException 발생 + Toss Auto-Cancel 호출
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(InternalServerException.class);
 
                 verify(paymentGatewayPort, times(1)).cancelPayment(eq(PAYMENT_KEY), anyString());
@@ -380,7 +386,7 @@ class MoneyServiceTest {
 
                 // when & then: InternalServerException 발생
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(InternalServerException.class);
 
                 // Toss + 로컬 DB 모두 정상 취소 상태 -> Critical Alert 미발행
@@ -407,7 +413,7 @@ class MoneyServiceTest {
 
                 // when & then: 예외 발생
                 assertThatThrownBy(() ->
-                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getId())
+                        moneyService.processRechargeSuccess(PAYMENT_KEY, ORDER_ID, AMOUNT, member.getEmail())
                 ).isInstanceOf(Exception.class);
 
                 // Critical: Auto-Cancel 실패 -> AutoCancelFailureEvent 발행


### PR DESCRIPTION
## 변경 사항 요약

낙관적 락을 실제 적용·측정하여 비관적 락 선택 근거를 수치로 확보

Closes #71

---

## 주요 변경 사항

### 1. 낙관적 락 실험 코드

**Wallet**

- `@Version private Long version` 추가 → Hibernate가 `UPDATE ... WHERE version = ?` 조건을 붙여 커밋 시점 충돌 감지

**WalletServiceImpl**

- `findWallet()` (락 없이 조회) + `@Retryable(maxAttempts=5, delay=50ms, multiplier=2.0)` 적용
- 충돌 발생 시 지수 백오프로 최대 5회 재시도

**MoneyDepositorRetryFacade**

- `ObjectOptimisticLockingFailureException`을 `retryFor`에 추가하여 Facade 레벨에서 재시도 처리
- retry 설정 기본값 추가 (max-attempts:5, delay:50, multiplier:2.0)

### 2. 비관적 락 복원 (현재 활성)

**WalletServiceImpl**

- `@Retryable` 주석 처리, `findWalletWithLock()` (FOR UPDATE) 활성화 복원

**Wallet**

- `@Version` 주석 처리

### 3. 비교 통합 테스트 신규 작성

**WalletLockComparisonIntegrationTest**

- 100 스레드가 동시에 동일 지갑에 1,000원씩 입금하는 시나리오로 양쪽 전략 측정
- `AtomicInteger`로 성공/실패 건수, `ConcurrentLinkedQueue`로 응답시간 수집
- `CountDownLatch`로 모든 스레드가 동시에 출발하도록 보장

---

## 동작 흐름

### 낙관적 락 흐름

```
findWallet() — 락 없이 SELECT
  → depositMoney() — 잔액 변경 (메모리)
  → 커밋 시점 UPDATE wallet SET balance=? WHERE id=? AND version=N
    → version 불일치(다른 스레드가 먼저 커밋) → 0 rows updated
    → ObjectOptimisticLockingFailureException 발생
      → MoneyDepositorRetryFacade @Retryable 개입
      → 새 트랜잭션으로 재시도 (최대 5회, 지수 백오프)
        → 5회 초과 → 예외 전파 → Auto-Cancel 연쇄 발동
```

### 비관적 락 흐름 (현재 활성)

```
findWalletWithLock() — SELECT ... FOR UPDATE
  → 락 획득 성공한 스레드만 진입
  → depositMoney() — 잔액 변경
  → 커밋 — 락 해제
    → 대기 중인 다음 스레드가 락 획득
    → 반복 직렬화
```

### 버그: @Retryable이 WalletServiceImpl에서 동작하지 않는 이유

```
MoneyDepositor.deposit() — @Transactional (외부 트랜잭션 시작)
  → walletService.depositMoney() — REQUIRED로 합류 (별도 트랜잭션 없음)
    → ObjectOptimisticLockingFailureException은 외부 트랜잭션 커밋 시점에 발생
    → depositMoney()의 @Retryable AOP는 이 예외를 볼 수 없음
      → Facade 레벨로 올려야 각 재시도가 새 트랜잭션에서 실행됨
```

---

## 기술적 의사결정

### 왜 비관적 락인가?

**문제**

- 낙관락은 충돌 빈도가 높은 단일 지갑에 100건 동시 접근 시 재시도 폭풍(retry storm)이 발생

**해결**

- 비관적 락(FOR UPDATE)으로 직렬화 → 전원 성공, 재시도 0회

**비교 — 낙관적 락 (maxAttempts=5)**

- 성공 62건, 실패 38건 — 재시도 한도(5회)를 모두 소진한 스레드가 Auto-Cancel까지 연쇄 발동하여 충전 누락 발생
- 재시도 총 327회 — 충돌이 중첩될수록 재시도가 기하급수적으로 누적
- 응답시간 avg 1,295ms / max 1,808ms — 재시도 백오프가 쌓여 예측 불가능한 지연 발생
- 최종 잔액 62,000원 — 38건 누락, 금융 도메인 허용 불가

**비교 — 비관적 락 (FOR UPDATE)**

- 성공 100건, 실패 0건 — 직렬화로 전원 처리, 잔액 100,000원 정합성 보장
- 재시도 0회 — 충돌 자체가 발생하지 않음
- 응답시간 avg 434ms / max 815ms — 대기가 직선적으로 누적되어 예측 가능한 지연
- Mean Test Time(nGrinder VU 100) 2,934ms — 단일 지갑 직렬화 특성상 후순위 스레드 대기 누적이나 100건 전원 성공