### PR TITLE
[test] 자산 갱신 동시성 락 4종 비교 시나리오 도입

### DIFF
--- a/src/test/java/com/ureca/snac/integration/WalletLockComparisonIntegrationTest.java
+++ b/src/test/java/com/ureca/snac/integration/WalletLockComparisonIntegrationTest.java
@@ -19,18 +19,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * 낙관적 락 vs 비관적 락 동시성 비교 통합 테스트
+ * 락 전략 동시성 비교 통합 테스트
  * <p>
- * [낙관적 락]
- * Wallet.@Version + depositMoney() @Retryable(maxAttempts=5)
- * 측정: successCount=100, retryCount(충돌 재시도 총합), 응답시간 분산
+ * 시나리오: 리스너(보너스 지급) · 충전 API · 스케줄러(에스크로 환불)가
+ * 동시에 같은 지갑을 갱신하는 실제 경합 구조를 재현
+ * 동일 지갑 행에 대한 동시성 read-modify-write로 잔액 유실을 재현
  * <p>
- * [비관적 락]
- * depositMoney() findByMemberIdWithLock() (FOR UPDATE)
- * 측정: successCount=100, retryCount=0, 응답시간 분산
- * <p>
- * 정합성은 동일하게 보장되지만, 고경합 환경에서 낙관락은
- * 재시도로 응답시간 분산이 현저히 높아짐.
+ * 브랜치별 구현
+ * experiment/jvm-lock         : SynchronizedWalletFacade (per-member ReentrantLock+ Facade)
+ * experiment/cas              : Atomic SQL UPDATE
+ * experiment/optimistic-lock  : @Version + @Retryable
+ * experiment/pessimistic-lock : pessimistic lock (FOR UPDATE)
  */
 @DisplayName("지갑 락 전략 동시성 비교 통합 테스트")
 class WalletLockComparisonIntegrationTest extends IntegrationTestSupport {
@@ -40,98 +39,157 @@ class WalletLockComparisonIntegrationTest extends IntegrationTestSupport {
 
     private Member member;
 
-    private static final long DEPOSIT_AMOUNT = 1000L;
-    private static final int THREAD_COUNT = 100;
+    private static final int GROUP_SIZE = 30;   // 그룹당 스레드 수 (총 90개)
+    private static final long AMOUNT = 1000L;
 
     @BeforeEach
     void setUp() {
         member = createMemberWithWallet("lock_cmp_");
+
+        // 스케줄러(Group C)가 환불할 에스크로 사전 적립
+        walletService.depositMoney(member.getId(), GROUP_SIZE * AMOUNT);
+        walletService.moveCompositeToEscrow(member.getId(), GROUP_SIZE * AMOUNT, 0);
     }
 
     @Test
-    @DisplayName("100 스레드 동시 입금 → 전원 성공, 잔액 정합성 보장")
-    void concurrent_deposit_allSucceed_balanceConsistent() throws InterruptedException {
-        // when
-        AtomicInteger successCount = new AtomicInteger();
+    @DisplayName("리스너·충전 API·스케줄러 동시 접근 → 잔액 정합성 보장")
+    void concurrentMultiPath_balanceConsistent() throws InterruptedException {
+
+        AtomicInteger successA = new AtomicInteger(); // 리스너
+        AtomicInteger successB = new AtomicInteger(); // 충전 API
+        AtomicInteger successC = new AtomicInteger(); // 스케줄러
         AtomicInteger failCount = new AtomicInteger();
-        ConcurrentLinkedQueue<Long> elapsedTimesMs = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<Long> elapsedTimes = new ConcurrentLinkedQueue<>();
 
-        runConcurrently(() -> {
-            long start = System.currentTimeMillis();
-            try {
-                walletService.depositMoney(member.getId(), DEPOSIT_AMOUNT);
-                successCount.incrementAndGet();
-            } catch (Exception e) {
-                failCount.incrementAndGet();
-            } finally {
-                elapsedTimesMs.add(System.currentTimeMillis() - start);
-            }
-        }, THREAD_COUNT);
+        int totalThreads = GROUP_SIZE * 3;
+        ExecutorService executor = Executors.newFixedThreadPool(totalThreads);
 
-        // then
-        long retryCount = -1; // 비관락: 재시도 없음. 낙관락 브랜치에서는 WalletRetryListener 복구 후 측정
+        // 모든 스레드가 준비 완료됐음을 메인 스레드에 알리는 latch
+        CountDownLatch ready = new CountDownLatch(totalThreads);
+        // 메인 스레드가 전원 준비 확인 후 동시 출발시키는 latch
+        CountDownLatch start = new CountDownLatch(1);
 
-        LongSummaryStatistics stats = elapsedTimesMs.stream()
-                .mapToLong(Long::longValue)
-                .summaryStatistics();
-
-        Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
-        long finalBalance = wallet.getMoneyBalance();
-
-        printResult(successCount.get(), failCount.get(), retryCount, stats, finalBalance);
-
-        // 잔액 정합성: 성공한 건수 × 금액만큼만 정확히 반영됐는가
-        // (낙관락은 재시도 한도 초과 시 실패 건수 발생, 비관락은 0건)
-        assertThat(finalBalance)
-                .as("잔액 = 성공 건수 × 입금액 (팬텀 라이트 없음)")
-                .isEqualTo(DEPOSIT_AMOUNT * successCount.get());
-
-        assertThat(successCount.get() + failCount.get())
-                .as("전체 스레드가 완료됐는가")
-                .isEqualTo(THREAD_COUNT);
-    }
-
-    // ==================== helper ====================
-
-    private void runConcurrently(Runnable task, int threadCount) throws InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch ready = new CountDownLatch(1);
         List<Future<?>> futures = new ArrayList<>();
 
-        for (int i = 0; i < threadCount; i++) {
+        // Group A: 리스너 — depositPoint
+        for (int i = 0; i < GROUP_SIZE; i++) {
             futures.add(executor.submit(() -> {
+                ready.countDown();
                 try {
-                    ready.await();
-                    task.run();
+                    start.await();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    return;
+                }
+                long begin = System.currentTimeMillis();
+                try {
+                    walletService.depositPoint(member.getId(), AMOUNT);
+                    successA.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    elapsedTimes.add(System.currentTimeMillis() - begin);
                 }
             }));
         }
 
-        ready.countDown();
+        // Group B: 충전 API — depositMoney
+        for (int i = 0; i < GROUP_SIZE; i++) {
+            futures.add(executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                long begin = System.currentTimeMillis();
+                try {
+                    walletService.depositMoney(member.getId(), AMOUNT);
+                    successB.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    elapsedTimes.add(System.currentTimeMillis() - begin);
+                }
+            }));
+        }
+
+        // Group C: 스케줄러 — cancelCompositeEscrow (에스크로 환불)
+        for (int i = 0; i < GROUP_SIZE; i++) {
+            futures.add(executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                long begin = System.currentTimeMillis();
+                try {
+                    walletService.cancelCompositeEscrow(member.getId(), AMOUNT, 0);
+                    successC.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    elapsedTimes.add(System.currentTimeMillis() - begin);
+                }
+            }));
+        }
+
+        // 전원 준비 완료 대기 후 동시 출발
+        ready.await();
+        start.countDown();
 
         for (Future<?> future : futures) {
             try {
-                future.get(60, TimeUnit.SECONDS);
+                future.get(120, TimeUnit.SECONDS);
             } catch (ExecutionException ignored) {
             } catch (TimeoutException e) {
-                fail("태스크가 60초 내 완료되지 않음: " + e.getMessage());
+                fail("태스크가 120초 내 완료되지 않음: " + e.getMessage());
             }
         }
 
         executor.shutdown();
-        executor.awaitTermination(70, TimeUnit.SECONDS);
+        executor.awaitTermination(130, TimeUnit.SECONDS);
+
+        LongSummaryStatistics stats = elapsedTimes.stream()
+                .mapToLong(Long::longValue)
+                .summaryStatistics();
+
+        Wallet wallet = walletRepository.findByMemberId(member.getId()).orElseThrow();
+
+        printResult(successA.get(), successB.get(), successC.get(), failCount.get(), stats, wallet);
+
+        // 정합성 검증: 성공한 만큼만 정확히 반영됐는가
+        long expectedMoney = (successB.get() * AMOUNT) + (successC.get() * AMOUNT);
+        long expectedPoint = successA.get() * AMOUNT;
+        long expectedEscrow = (GROUP_SIZE - successC.get()) * AMOUNT;
+
+        assertThat(wallet.getMoneyBalance())
+                .as("머니 잔액 = 충전 성공분 + 에스크로 환불 성공분")
+                .isEqualTo(expectedMoney);
+
+        assertThat(wallet.getPointBalance())
+                .as("포인트 잔액 = 보너스 지급 성공분")
+                .isEqualTo(expectedPoint);
+
+        assertThat(wallet.getMoneyEscrow())
+                .as("에스크로 = 초기 적립 - 환불 성공분")
+                .isEqualTo(expectedEscrow);
     }
 
-    private void printResult(int successCount, int failCount, long retryCount,
-                             LongSummaryStatistics stats, long finalBalance) {
+    private void printResult(int successA, int successB, int successC, int failCount,
+                             LongSummaryStatistics stats, Wallet wallet) {
         System.out.println("\n========== 락 전략 비교 결과 ==========");
-        System.out.printf("성공 건수    : %d / %d%n", successCount, THREAD_COUNT);
-        System.out.printf("실패 건수    : %d  ← 낙관락=재시도 한도 초과, 비관락=0 기대%n", failCount);
-        System.out.printf("재시도 횟수  : %s%n", retryCount >= 0 ? retryCount + " (낙관락 충돌 재시도 총합)" : "N/A (비관락)");
-        System.out.printf("최종 잔액    : %,d원%n", finalBalance);
-        System.out.printf("응답시간(ms) : min=%-4d  max=%-4d  avg=%.1f%n",
+        System.out.printf("리스너   (depositPoint)            : %d / %d 성공%n", successA, GROUP_SIZE);
+        System.out.printf("충전 API  (depositMoney)           : %d / %d 성공%n", successB, GROUP_SIZE);
+        System.out.printf("스케줄러  (cancelCompositeEscrow)  : %d / %d 성공%n", successC, GROUP_SIZE);
+        System.out.printf("실패 건수                       : %d%n", failCount);
+        System.out.printf("머니 잔액                       : %,d원%n", wallet.getMoneyBalance());
+        System.out.printf("포인트 잔액                     : %,d원%n", wallet.getPointBalance());
+        System.out.printf("에스크로 잔액                   : %,d원%n", wallet.getMoneyEscrow());
+        System.out.printf("응답시간(ms)                    : min=%-4d  max=%-4d  avg=%.1f%n",
                 stats.getMin(), stats.getMax(), stats.getAverage());
         System.out.println("=========================================\n");
     }


### PR DESCRIPTION
## 변경 사항 요약

자산 갱신 동시성 락 4종(CAS·JVM 락·낙관적 락·비관적 락) 비교를 위한
90 스레드 3그룹 시나리오를 통합 테스트에 도입.

Related #73

---

## 주요 변경 사항

### 1. 락 전략 비교 시나리오 교체

**WalletLockComparisonIntegrationTest**

- 100 스레드 단일(`depositMoney`) → 90 스레드 3그룹(`depositPoint` · `depositMoney` · `cancelCompositeEscrow`)
- 리스너·충전 API·스케줄러가 동일 지갑 row에 수렴하는 실제 경합 구조 재현
- CountDownLatch 2단(ready·start)으로 전원 동시 출발 보장
- 잔액·포인트·에스크로 3가지 정합성 검증

---

## 동작 흐름

### 정상 흐름

```
30 스레드 depositPoint           ┐
30 스레드 depositMoney           ├── 동시 출발 → 90건 처리 → 정합성 검증
30 스레드 cancelCompositeEscrow  ┘
```

---

## 기술적 의사결정

### 왜 5종 후보 중 4종만 실험하는가?

**문제**
- 동일 지갑 row에 보너스 지급·충전·취소·환불 진입점이 락 없이 동시 read-modify-write 수행 시 잔액 유실 가능
- 락 선택 근거 수치화 필요

**해결**
- 후보 5종(MQ concurrency=1·CAS·JVM 락·낙관적 락·비관적 락) 사전 검토
- 4종(CAS·JVM 락·낙관적 락·비관적 락) 실험 대상 확정

**비교**
- MQ concurrency=1: 기술적으로 직렬화 가능. 그러나 충전 직후 거래에서 read-your-own-write 보장 실패 (consumer 처리 완료 전 거래 API 잔액 미반영), 회원별 단일 큐로 라우팅 복잡도 증가, Wallet 애그리거트 불변식을 인프라 설정에 위임. 금융 도메인에서 허용 어려움 → 배제

### 왜 90 스레드 3그룹 시나리오인가?

**문제**
- 단일 메서드(`depositMoney`) 100 스레드 시나리오는 #71/#72의 낙관적 락 vs 비관적 락 2-way 측정용
- 4종 비교에서는 보너스 지급·충전·환불 진입점이 동시 수렴하는 실제 경합을 재현해야 의미 있음

**해결**
- Group A 리스너(`depositPoint`) 30 + Group B 충전 API(`depositMoney`) 30 + Group C 스케줄러(`cancelCompositeEscrow`) 30
- 각 그룹이 다른 메서드를 호출하면서도 동일 지갑 row에 수렴 → 진입점 다양성과 경합 동시 재현
- 4개 experiment 브랜치가 동일 테스트를 공유, 측정값 직접 비교 가능