### PR TITLE
[feat] 충전 재시도 메트릭 추가

### DIFF
--- a/src/main/java/com/ureca/snac/loadtest/FaultInjectionAspect.java
+++ b/src/main/java/com/ureca/snac/loadtest/FaultInjectionAspect.java
@@ -6,6 +6,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
+import org.springframework.dao.TransientDataAccessResourceException;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.ThreadLocalRandom;
@@ -16,8 +17,11 @@ import java.util.concurrent.ThreadLocalRandom;
  * MoneyDepositor.deposit() 에 확률적 예외를 발생시켜
  * "Toss 승인 성공 + DB 실패" 시나리오를 유발한다.
  * <p>
- * RuntimeException 을 던지므로 @Retryable(retryFor = DataAccessException) 에 해당하지 않아
- * 재시도 없이 즉시 Auto-Cancel chain 이 발동한다.
+ * deposit-failure-type
+ * runtime: RuntimeException -> @Retryable 매칭 안 됨, 즉시 Auto-Cancel chain (보상 검증)
+ * transient: TransientDataAccessResourceException -> @Retryable 트리거 (재시도 검증)
+ * <p>
+ * 매 @Around 실행마다 독립 dice -? per-attempt independent.
  */
 @Slf4j
 @Aspect
@@ -28,10 +32,17 @@ public class FaultInjectionAspect {
     @Value("${loadtest.fault.deposit-failure-rate}")
     private double depositFailureRate;
 
+    @Value("${loadtest.fault.deposit-failure-type:runtime}")
+    private String depositFailureType;
+
     @Around("execution(* com.ureca.snac.money.service.MoneyDepositor.deposit(..))")
     public Object injectDepositFault(ProceedingJoinPoint joinPoint) throws Throwable {
         if (ThreadLocalRandom.current().nextDouble() < depositFailureRate) {
-            log.warn("[LoadTest 장애 주입] MoneyDepositor.deposit() 예외 발생");
+            log.warn("[LoadTest 장애 주입] MoneyDepositor.deposit() 예외 발생. type: {}", depositFailureType);
+            if ("transient".equalsIgnoreCase(depositFailureType)) {
+                throw new TransientDataAccessResourceException(
+                        "[LoadTest] Injected transient DB failure for retry test");
+            }
             throw new RuntimeException("[LoadTest] Injected deposit failure for compensation test");
         }
         return joinPoint.proceed();

--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositor.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositor.java
@@ -10,8 +10,6 @@ import com.ureca.snac.payment.exception.UnsupportedPaymentMethodException;
 import com.ureca.snac.payment.port.out.dto.PaymentConfirmResult;
 import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.wallet.service.WalletService;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,45 +31,33 @@ public class MoneyDepositor {
     private final MoneyRechargeRepository moneyRechargeRepository;
     private final WalletService walletService;
     private final AssetRecorder assetRecorder;
-    private final MeterRegistry meterRegistry;
 
     @Transactional
     public void deposit(Long paymentId, Long memberId, PaymentConfirmResult confirmResult) {
-        Timer.Sample sample = Timer.start(meterRegistry);
-        String outcome = "success";
-        try {
-            log.info("[머니 입금 처리] DB 상태 변경 시작. paymentId : {}", paymentId);
+        log.info("[머니 입금 처리] DB 상태 변경 시작. paymentId : {}", paymentId);
 
-            // FOR UPDATE 락으로 Payment 재조회
-            Payment lockedPayment = paymentRepository.findByIdForUpdate(paymentId)
-                    .orElseThrow(PaymentNotFoundException::new);
+        // FOR UPDATE 락으로 Payment 재조회
+        Payment lockedPayment = paymentRepository.findByIdForUpdate(paymentId)
+                .orElseThrow(PaymentNotFoundException::new);
 
-            PaymentMethod method = PaymentMethod.fromTossMethod(confirmResult.method());
-            if (method == PaymentMethod.UNKNOWN) {
-                log.error("[머니 입금 처리] 알 수 없는 결제 수단. paymentId: {}, method: {}",
-                        paymentId, confirmResult.method());
-                throw new UnsupportedPaymentMethodException();
-            }
-
-            lockedPayment.complete(confirmResult.paymentKey(), method, confirmResult.approvedAt());
-            log.info("[머니 입금 처리] Payment 엔티티 SUCCESS 변경 완료");
-
-            MoneyRecharge recharge = MoneyRecharge.create(lockedPayment);
-            moneyRechargeRepository.save(recharge);
-            log.info("[머니 입금 처리] MoneyRecharge 기록 생성 완료. rechargeId : {}", recharge.getId());
-
-            Long balanceAfter = walletService.depositMoney(memberId, lockedPayment.getAmount());
-            log.info("[머니 입금 처리] 지갑 머니 입금 완료. memberId : {} , 최종 잔액 : {}", memberId, balanceAfter);
-
-            assetRecorder.recordMoneyRecharge(memberId, lockedPayment.getId(), recharge.getPaidAmountWon(), balanceAfter);
-            log.info("[머니 입금 처리] 자산 변동 기록 직접 저장 완료.");
-        } catch (Throwable t) {
-            outcome = "fail";
-            throw t;
-        } finally {
-            sample.stop(Timer.builder("db_depositor_duration")
-                    .tag("outcome", outcome)
-                    .register(meterRegistry));
+        PaymentMethod method = PaymentMethod.fromTossMethod(confirmResult.method());
+        if (method == PaymentMethod.UNKNOWN) {
+            log.error("[머니 입금 처리] 알 수 없는 결제 수단. paymentId: {}, method: {}",
+                    paymentId, confirmResult.method());
+            throw new UnsupportedPaymentMethodException();
         }
+
+        lockedPayment.complete(confirmResult.paymentKey(), method, confirmResult.approvedAt());
+        log.info("[머니 입금 처리] Payment 엔티티 SUCCESS 변경 완료");
+
+        MoneyRecharge recharge = MoneyRecharge.create(lockedPayment);
+        moneyRechargeRepository.save(recharge);
+        log.info("[머니 입금 처리] MoneyRecharge 기록 생성 완료. rechargeId : {}", recharge.getId());
+
+        Long balanceAfter = walletService.depositMoney(memberId, lockedPayment.getAmount());
+        log.info("[머니 입금 처리] 지갑 머니 입금 완료. memberId : {} , 최종 잔액 : {}", memberId, balanceAfter);
+
+        assetRecorder.recordMoneyRecharge(memberId, lockedPayment.getId(), recharge.getPaidAmountWon(), balanceAfter);
+        log.info("[머니 입금 처리] 자산 변동 기록 직접 저장 완료.");
     }
 }

--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositor.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositor.java
@@ -10,6 +10,8 @@ import com.ureca.snac.payment.exception.UnsupportedPaymentMethodException;
 import com.ureca.snac.payment.port.out.dto.PaymentConfirmResult;
 import com.ureca.snac.payment.repository.PaymentRepository;
 import com.ureca.snac.wallet.service.WalletService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,33 +33,45 @@ public class MoneyDepositor {
     private final MoneyRechargeRepository moneyRechargeRepository;
     private final WalletService walletService;
     private final AssetRecorder assetRecorder;
+    private final MeterRegistry meterRegistry;
 
     @Transactional
     public void deposit(Long paymentId, Long memberId, PaymentConfirmResult confirmResult) {
-        log.info("[머니 입금 처리] DB 상태 변경 시작. paymentId : {}", paymentId);
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "success";
+        try {
+            log.info("[머니 입금 처리] DB 상태 변경 시작. paymentId : {}", paymentId);
 
-        // FOR UPDATE 락으로 Payment 재조회
-        Payment lockedPayment = paymentRepository.findByIdForUpdate(paymentId)
-                .orElseThrow(PaymentNotFoundException::new);
+            // FOR UPDATE 락으로 Payment 재조회
+            Payment lockedPayment = paymentRepository.findByIdForUpdate(paymentId)
+                    .orElseThrow(PaymentNotFoundException::new);
 
-        PaymentMethod method = PaymentMethod.fromTossMethod(confirmResult.method());
-        if (method == PaymentMethod.UNKNOWN) {
-            log.error("[머니 입금 처리] 알 수 없는 결제 수단. paymentId: {}, method: {}",
-                    paymentId, confirmResult.method());
-            throw new UnsupportedPaymentMethodException();
+            PaymentMethod method = PaymentMethod.fromTossMethod(confirmResult.method());
+            if (method == PaymentMethod.UNKNOWN) {
+                log.error("[머니 입금 처리] 알 수 없는 결제 수단. paymentId: {}, method: {}",
+                        paymentId, confirmResult.method());
+                throw new UnsupportedPaymentMethodException();
+            }
+
+            lockedPayment.complete(confirmResult.paymentKey(), method, confirmResult.approvedAt());
+            log.info("[머니 입금 처리] Payment 엔티티 SUCCESS 변경 완료");
+
+            MoneyRecharge recharge = MoneyRecharge.create(lockedPayment);
+            moneyRechargeRepository.save(recharge);
+            log.info("[머니 입금 처리] MoneyRecharge 기록 생성 완료. rechargeId : {}", recharge.getId());
+
+            Long balanceAfter = walletService.depositMoney(memberId, lockedPayment.getAmount());
+            log.info("[머니 입금 처리] 지갑 머니 입금 완료. memberId : {} , 최종 잔액 : {}", memberId, balanceAfter);
+
+            assetRecorder.recordMoneyRecharge(memberId, lockedPayment.getId(), recharge.getPaidAmountWon(), balanceAfter);
+            log.info("[머니 입금 처리] 자산 변동 기록 직접 저장 완료.");
+        } catch (Throwable t) {
+            outcome = "fail";
+            throw t;
+        } finally {
+            sample.stop(Timer.builder("db_depositor_duration")
+                    .tag("outcome", outcome)
+                    .register(meterRegistry));
         }
-
-        lockedPayment.complete(confirmResult.paymentKey(), method, confirmResult.approvedAt());
-        log.info("[머니 입금 처리] Payment 엔티티 SUCCESS 변경 완료");
-
-        MoneyRecharge recharge = MoneyRecharge.create(lockedPayment);
-        moneyRechargeRepository.save(recharge);
-        log.info("[머니 입금 처리] MoneyRecharge 기록 생성 완료. rechargeId : {}", recharge.getId());
-
-        Long balanceAfter = walletService.depositMoney(memberId, lockedPayment.getAmount());
-        log.info("[머니 입금 처리] 지갑 머니 입금 완료. memberId : {} , 최종 잔액 : {}", memberId, balanceAfter);
-
-        assetRecorder.recordMoneyRecharge(memberId, lockedPayment.getId(), recharge.getPaidAmountWon(), balanceAfter);
-        log.info("[머니 입금 처리] 자산 변동 기록 직접 저장 완료.");
     }
 }

--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryFacade.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryFacade.java
@@ -30,7 +30,7 @@ public class MoneyDepositorRetryFacade {
             // MoneyDepositor.deposit() 커밋 시점에 예외 발생
             // depositMoney()의 @Retryable은 외부 트랜잭션 합류로 동작 안 하므로 Facade 레벨에서 처리
             // retryFor = {TransientDataAccessException.class, ObjectOptimisticLockingFailureException.class},
-            // listeners = "walletRetryListener",
+            listeners = "moneyDepositorRetryListener",
             retryFor = {TransientDataAccessException.class},
             maxAttemptsExpression = "${retry.depositor.max-attempts:5}",
             backoff = @Backoff(delayExpression = "${retry.depositor.delay:50}",

--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryFacade.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryFacade.java
@@ -48,9 +48,7 @@ public class MoneyDepositorRetryFacade {
             outcome = "fail";
             throw t;
         } finally {
-            sample.stop(Timer.builder("db_depositor_duration")
-                    .tag("outcome", outcome)
-                    .register(meterRegistry));
+            sample.stop(meterRegistry.timer("db_depositor_duration", "outcome", outcome));
         }
     }
 }

--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryFacade.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryFacade.java
@@ -1,6 +1,8 @@
 package com.ureca.snac.money.service;
 
 import com.ureca.snac.payment.port.out.dto.PaymentConfirmResult;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.retry.annotation.Backoff;
@@ -24,6 +26,7 @@ import org.springframework.stereotype.Service;
 public class MoneyDepositorRetryFacade {
 
     private final MoneyDepositor moneyDepositor;
+    private final MeterRegistry meterRegistry;
 
     @Retryable(
             // [낙관락]
@@ -37,6 +40,17 @@ public class MoneyDepositorRetryFacade {
                     multiplierExpression = "${retry.depositor.multiplier:2.0}")
     )
     public void deposit(Long paymentId, Long memberId, PaymentConfirmResult confirmResult) {
-        moneyDepositor.deposit(paymentId, memberId, confirmResult);
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "success";
+        try {
+            moneyDepositor.deposit(paymentId, memberId, confirmResult);
+        } catch (Throwable t) {
+            outcome = "fail";
+            throw t;
+        } finally {
+            sample.stop(Timer.builder("db_depositor_duration")
+                    .tag("outcome", outcome)
+                    .register(meterRegistry));
+        }
     }
 }

--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryListener.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryListener.java
@@ -1,0 +1,61 @@
+package com.ureca.snac.money.service;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * MoneyDepositorRetryFacade.deposit() 시도별 메트릭
+ * <p>
+ * retry_attempt_outcome_total{attempt, result} : 시도별 성공·실패 카운트
+ * retry_total_duration{outcome} : 백오프 포함 누적 시간
+ */
+@Component("moneyDepositorRetryListener")
+@RequiredArgsConstructor
+public class MoneyDepositorRetryListener implements RetryListener {
+
+    private static final String START_NANOS_KEY = "moneyDepositor.startNanos";
+
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
+        context.setAttribute(START_NANOS_KEY, System.nanoTime());
+        return true;
+    }
+
+    @Override
+    public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+        int failedAttempt = context.getRetryCount();
+        meterRegistry.counter("retry_attempt_outcome_total",
+                        "attempt", String.valueOf(failedAttempt),
+                        "result", "fail")
+                .increment();
+    }
+
+    @Override
+    public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+        Object start = context.getAttribute(START_NANOS_KEY);
+        if (start instanceof Long startNanos) {
+            long durationNanos = System.nanoTime() - startNanos;
+            Timer.builder("retry_total_duration")
+                    .tag("outcome", throwable == null ? "success" : "exhausted")
+                    .register(meterRegistry)
+                    .record(durationNanos, TimeUnit.NANOSECONDS);
+        }
+
+        if (throwable == null) {
+            int successAttempt = context.getRetryCount() + 1;
+            meterRegistry.counter("retry_attempt_outcome_total",
+                            "attempt", String.valueOf(successAttempt),
+                            "result", "success")
+                    .increment();
+        }
+    }
+}

--- a/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryListener.java
+++ b/src/main/java/com/ureca/snac/money/service/MoneyDepositorRetryListener.java
@@ -1,7 +1,6 @@
 package com.ureca.snac.money.service;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
@@ -44,9 +43,7 @@ public class MoneyDepositorRetryListener implements RetryListener {
         Object start = context.getAttribute(START_NANOS_KEY);
         if (start instanceof Long startNanos) {
             long durationNanos = System.nanoTime() - startNanos;
-            Timer.builder("retry_total_duration")
-                    .tag("outcome", throwable == null ? "success" : "exhausted")
-                    .register(meterRegistry)
+            meterRegistry.timer("retry_total_duration", "outcome", throwable == null ? "success" : "exhausted")
                     .record(durationNanos, TimeUnit.NANOSECONDS);
         }
 

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -6,6 +6,16 @@ server:
     threads:
       max: 100
 
+# Timer 메트릭 histogram bucket 발행 (PromQL histogram_quantile 사용)
+# 키 이름은 Timer.builder() 의 메트릭 ID와 동일해야 함 (underscore 그대로)
+management:
+  metrics:
+    distribution:
+      percentiles-histogram:
+        payment_approval_duration: true
+        db_depositor_duration: true
+        retry_total_duration: true
+
 spring:
   main:
     allow-bean-definition-overriding: true
@@ -24,7 +34,15 @@ payments:
 loadtest:
   fault:
     deposit-failure-rate: 0.0     # 기본 비활성. Performance Test 시 JVM 인자로 활성화: -Dloadtest.fault.deposit-failure-rate=0.10
+    deposit-failure-type: runtime # runtime(기본, 즉시 Auto-Cancel) | transient(재시도 검증용 TransientDataAccessResourceException)
     cancel-failure-rate: 0.0      # 기본 비활성. Performance Test 시 JVM 인자로 활성화: -Dloadtest.fault.cancel-failure-rate=0.02
+
+# 재시도 설정
+retry:
+  depositor:
+    max-attempts: 4               # 1~5 비교 실험 최적값
+    delay: 500                    # 첫 백오프 (ms)
+    multiplier: 2.0               # 지수 백오프 배수
 
 # 대사 스케줄러 부하 테스트에서 빠르게 동작하도록 조정
 reconciliation:


### PR DESCRIPTION
## 변경 사항 요약

충전 흐름의 재시도 메커니즘 관찰성 메트릭 추가. 시도별 회복률·백오프 비용 측정으로 max-attempts 결정 근거 확보.

---

## 주요 변경 사항

### 1. 시도별 retry 메트릭

**MoneyDepositorRetryListener** (신규)

- `retry_attempt_outcome_total{attempt, result}` — 시도별 성공·실패 카운터
- `retry_total_duration{outcome}` — 백오프 포함 누적 시간

**MoneyDepositorRetryFacade**

- `moneyDepositorRetryListener` 연결

### 2. 단일 DB 시도 시간

**MoneyDepositor**

- `db_depositor_duration` Timer inline 래핑

### 3. 부하 테스트 실험 인프라

**FaultInjectionAspect**

- `deposit-failure-type` config 추가 (runtime/transient)
- transient 모드로 `@Retryable` 매칭 가능

**application-loadtest.yml**

- Timer 메트릭 histogram bucket 활성화 (P99 PromQL 사용)
- retry.depositor 기본값 갱신 (max-attempts=4, delay=500)

---

## 기술적 의사결정

### 왜 max-attempts=4인가?

**문제**

기존 max-attempts=3 은 관행·직감 기반, 수치 근거 부재.

**해결**

1~5 비교 실험 (delay=500, fault rate 10% per-attempt independent):

| N | P99 (ms) | 회복률 | Auto-Cancel |
|---|---|---|---|
| 3 | 1,470 | 99.88% | 15 |
| **4** | **1,439** | **99.985%** | **2** |
| 5 | 1,378 | 100% | 0 (attempt=5 미작동) |

- N=4: 모든 시도 메커니즘이 실제 작동 + Auto-Cancel 통계 유의 우위 (15 → 2)
- N=5: attempt=5 trigger 0 = 예비 버퍼
- P99 plateau 가 N=3 이후 시작 (~1450ms, SLA 2s 마진 확보)

### 왜 Timer inline 래핑인가?

기존 `MoneyServiceImpl`, `PaymentServiceImpl` 의 Timer 패턴과 동일. 별도 Aspect 대비 가시성·디버깅 유리.